### PR TITLE
ako/ use testlinks CF token

### DIFF
--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -80,8 +80,8 @@ jobs:
             - name: Publish to Cloudflare Pages
               id: publish-to-pages
               env:
-                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+                  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_TEST_LINK_TOKEN }}
+                  CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_TEST_LINK_ACCOUNT_ID }}
                   HEAD_BRANCH: ${{ github.head_ref }}
               run: |
                   echo "Installing Wrangler CLI"


### PR DESCRIPTION
To distinguish test links from other deployments.