### PR TITLE
fix: fixed endpoint can't be set manually

### DIFF
--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -22,10 +22,12 @@ export const getOauthUrl = () => {
     const origin = window.location.origin;
     const hostname = window.location.hostname;
 
+    const existingAppId = LocalStorageUtils.getValue(LocalStorageConstants.configAppId);
+    const existingServerUrl = localStorage.getItem(LocalStorageConstants.configServerURL.toString());
     // since we don't have official app_id for staging,
     // we will use the red server with app_id=62019 for the staging-p2p.deriv.com for now
     // to fix the login issue
-    if (origin === URLConstants.derivP2pStaging) {
+    if ((!existingAppId || !existingServerUrl) && origin === URLConstants.derivP2pStaging) {
         localStorage.setItem(
             LocalStorageConstants.configServerURL.toString(),
             SocketURL[origin as keyof typeof SocketURL]

--- a/src/constants/url.ts
+++ b/src/constants/url.ts
@@ -23,11 +23,11 @@ export const getOauthUrl = () => {
     const hostname = window.location.hostname;
 
     const existingAppId = LocalStorageUtils.getValue(LocalStorageConstants.configAppId);
-    const existingServerUrl = localStorage.getItem(LocalStorageConstants.configServerURL.toString());
+    const existingServerUrl = LocalStorageUtils.getValue(LocalStorageConstants.configServerURL);
     // since we don't have official app_id for staging,
     // we will use the red server with app_id=62019 for the staging-p2p.deriv.com for now
     // to fix the login issue
-    if ((!existingAppId || !existingServerUrl) && origin === URLConstants.derivP2pStaging) {
+    if (!/localhost/.test(origin) && (!existingAppId || !existingServerUrl)) {
         localStorage.setItem(
             LocalStorageConstants.configServerURL.toString(),
             SocketURL[origin as keyof typeof SocketURL]
@@ -38,8 +38,8 @@ export const getOauthUrl = () => {
         );
     }
 
-    const storedServerUrl = localStorage.getItem(LocalStorageConstants.configServerURL.toString());
-    const serverUrl = /qa/.test(storedServerUrl || '') ? storedServerUrl : 'oauth.deriv.com';
+    const storedServerUrl = LocalStorageUtils.getValue(LocalStorageConstants.configServerURL);
+    const serverUrl = /qa/.test(String(storedServerUrl)) ? storedServerUrl : 'oauth.deriv.com';
 
     const appId = LocalStorageUtils.getValue(LocalStorageConstants.configAppId);
 


### PR DESCRIPTION
## Issue:
Developers are unable to manually set the endpoint as it gets overridden by the default setting in the code.

## Changes:
Implemented a check for localStorage data to ensure that the default `server_url` and `app_id` for staging are only set if the user hasn't previously configured them manually.