### PR TITLE
Ameerul / FEQ-2459 Handling selected buy/sell and orders tabs

### DIFF
--- a/src/components/Modals/FilterModal/__tests__/FilterModal.spec.tsx
+++ b/src/components/Modals/FilterModal/__tests__/FilterModal.spec.tsx
@@ -44,7 +44,7 @@ const mockStore = {
 };
 
 jest.mock('@/stores', () => ({
-    useBuySellFiltersStore: jest.fn(() => mockStore),
+    useBuySellFiltersStore: jest.fn(selector => (selector ? selector(mockStore) : mockStore)),
 }));
 
 jest.mock('@deriv-com/ui', () => ({
@@ -322,5 +322,35 @@ describe('<FilterModal />', () => {
         await user.click(backButton);
 
         expect(screen.getByText('Filter')).toBeInTheDocument();
+    });
+
+    it('should show LeaveFilterModal when user tries to exit the FilterModal in mobile view', async () => {
+        mockModalManager.isModalOpenFor.mockImplementation(modalName => modalName === 'LeaveFilterModal');
+        render(<FilterModal {...mockProps} />);
+
+        const toggleSwitch = screen.getByRole('checkbox');
+        await user.click(toggleSwitch);
+
+        const closeIcon = screen.getByTestId('dt_mobile_wrapper_button');
+        await user.click(closeIcon);
+
+        expect(mockModalManager.showModal).toHaveBeenCalledWith('LeaveFilterModal');
+        expect(screen.getByText('Leave page?')).toBeInTheDocument();
+    });
+
+    it('should call hideModal when user clicks on the cancel button in LeaveFilterModal', async () => {
+        mockModalManager.isModalOpenFor.mockImplementation(modalName => modalName === 'LeaveFilterModal');
+        render(<FilterModal {...mockProps} />);
+
+        const toggleSwitch = screen.getByRole('checkbox');
+        await user.click(toggleSwitch);
+
+        const closeIcon = screen.getByTestId('dt_mobile_wrapper_button');
+        await user.click(closeIcon);
+
+        const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+        await user.click(cancelButton);
+
+        expect(mockModalManager.hideModal).toHaveBeenCalledWith({ shouldHideAllModals: false });
     });
 });

--- a/src/pages/buy-sell/screens/BuySellHeader/BuySellHeader.tsx
+++ b/src/pages/buy-sell/screens/BuySellHeader/BuySellHeader.tsx
@@ -93,7 +93,12 @@ const BuySellHeader = ({ setIsFilterModalOpen, setSearchValue }: TBuySellHeaderP
                     onClick={() => showModal('FilterModal')}
                     variant='outlined'
                 >
-                    {!!selectedPaymentMethods?.length && <div className='buy-sell-header__filter-button__indication' />}
+                    {!!selectedPaymentMethods?.length && (
+                        <div
+                            className='buy-sell-header__filter-button__indication'
+                            data-testid='dt_filter_button_indicator'
+                        />
+                    )}
                 </Button>
             </div>
             {isModalOpenFor('FilterModal') && <FilterModal isModalOpen onRequestClose={hideModal} />}

--- a/src/pages/buy-sell/screens/BuySellHeader/BuySellHeader.tsx
+++ b/src/pages/buy-sell/screens/BuySellHeader/BuySellHeader.tsx
@@ -1,10 +1,11 @@
+import { useEffect } from 'react';
 import { useShallow } from 'zustand/react/shallow';
 import { Search } from '@/components';
 import { FilterModal } from '@/components/Modals';
-import { getSortByList } from '@/constants';
-import { useModalManager } from '@/hooks/custom-hooks';
+import { ADVERT_TYPE, getSortByList } from '@/constants';
+import { useModalManager, useQueryString } from '@/hooks/custom-hooks';
 import { GuideTooltip } from '@/pages/guide/components';
-import { useBuySellFiltersStore } from '@/stores';
+import { useBuySellFiltersStore, useTabsStore } from '@/stores';
 import { getLocalizedTabs } from '@/utils/tabs';
 import { LabelPairedBarsFilterMdBoldIcon, LabelPairedBarsFilterSmBoldIcon } from '@deriv/quill-icons';
 import { useTranslations } from '@deriv-com/translations';
@@ -12,17 +13,18 @@ import { Button, Tab, Tabs, useDevice } from '@deriv-com/ui';
 import { CurrencyDropdown, SortDropdown } from '../../components';
 import './BuySellHeader.scss';
 
+const TABS = [ADVERT_TYPE.BUY, ADVERT_TYPE.SELL];
+
 type TBuySellHeaderProps = {
-    activeTab: string;
-    setActiveTab: (tab: number) => void;
     setIsFilterModalOpen: () => void;
     setSearchValue: (value: string) => void;
 };
 
-const BuySellHeader = ({ activeTab, setActiveTab, setIsFilterModalOpen, setSearchValue }: TBuySellHeaderProps) => {
+const BuySellHeader = ({ setIsFilterModalOpen, setSearchValue }: TBuySellHeaderProps) => {
     const { hideModal, isModalOpenFor, showModal } = useModalManager({ shouldReinitializeModals: false });
     const { localize } = useTranslations();
     const { isDesktop } = useDevice();
+    const { queryString, setQueryString } = useQueryString();
     const { filteredCurrency, selectedPaymentMethods, setFilteredCurrency, setSortByValue, sortByValue } =
         useBuySellFiltersStore(
             useShallow(state => ({
@@ -34,13 +36,30 @@ const BuySellHeader = ({ activeTab, setActiveTab, setIsFilterModalOpen, setSearc
             }))
         );
 
+    const { activeBuySellTab, setActiveBuySellTab } = useTabsStore(
+        useShallow(state => ({
+            activeBuySellTab: state.activeBuySellTab,
+            setActiveBuySellTab: state.setActiveBuySellTab,
+        }))
+    );
+
+    useEffect(() => {
+        if (queryString.tab) setActiveBuySellTab(queryString.tab);
+        else setQueryString({ tab: activeBuySellTab });
+    }, [activeBuySellTab, queryString.tab, setActiveBuySellTab, setQueryString]);
+
     return (
         <div className='buy-sell-header' data-testid='dt_buy_sell_header'>
             <div className='buy-sell-header__row justify-between'>
                 <Tabs
                     TitleFontSize={isDesktop ? 'sm' : 'md'}
-                    activeTab={getLocalizedTabs(localize)[activeTab]}
-                    onChange={setActiveTab}
+                    activeTab={getLocalizedTabs(localize)[activeBuySellTab]}
+                    onChange={index => {
+                        setActiveBuySellTab(TABS[index]);
+                        setQueryString({
+                            tab: TABS[index],
+                        });
+                    }}
                     variant='primary'
                     wrapperClassName='buy-sell-header__tabs'
                 >

--- a/src/pages/buy-sell/screens/BuySellTable/BuySellTable.tsx
+++ b/src/pages/buy-sell/screens/BuySellTable/BuySellTable.tsx
@@ -3,22 +3,18 @@ import { useShallow } from 'zustand/react/shallow';
 import { RadioGroupFilterModal } from '@/components/Modals';
 import { ADVERT_TYPE, BUY_SELL, getSortByList } from '@/constants';
 import { api } from '@/hooks';
-import { useModalManager, useQueryString } from '@/hooks/custom-hooks';
-import { useBuySellFiltersStore } from '@/stores';
+import { useModalManager } from '@/hooks/custom-hooks';
+import { useBuySellFiltersStore, useTabsStore } from '@/stores';
 import { TSortByValues } from '@/utils';
 import { useTranslations } from '@deriv-com/translations';
 import { BuySellHeader } from '../BuySellHeader';
 import { BuySellTableRenderer } from './BuySellTableRenderer';
 import './BuySellTable.scss';
 
-const TABS = [ADVERT_TYPE.BUY, ADVERT_TYPE.SELL];
-
 const BuySellTable = () => {
     const { localize } = useTranslations();
     const { hideModal, isModalOpenFor, showModal } = useModalManager({ shouldReinitializeModals: false });
     const { data: p2pSettingsData } = api.settings.useSettings();
-    const { queryString, setQueryString } = useQueryString();
-    const activeTab = queryString.tab || ADVERT_TYPE.BUY;
 
     const {
         filteredCurrency,
@@ -38,6 +34,12 @@ const BuySellTable = () => {
         }))
     );
 
+    const { activeBuySellTab } = useTabsStore(
+        useShallow(state => ({
+            activeBuySellTab: state.activeBuySellTab,
+        }))
+    );
+
     const [searchValue, setSearchValue] = useState<string>('');
 
     const {
@@ -47,7 +49,7 @@ const BuySellTable = () => {
         loadMoreAdverts,
     } = api.advert.useGetList({
         advertiser_name: searchValue,
-        counterparty_type: activeTab === ADVERT_TYPE.BUY ? BUY_SELL.BUY : BUY_SELL.SELL,
+        counterparty_type: activeBuySellTab === ADVERT_TYPE.BUY ? BUY_SELL.BUY : BUY_SELL.SELL,
         local_currency: filteredCurrency,
         payment_method: selectedPaymentMethods.length > 0 ? selectedPaymentMethods : undefined,
         sort_by: sortByValue,
@@ -59,12 +61,6 @@ const BuySellTable = () => {
         hideModal();
     };
 
-    const setActiveTab = (index: number) => {
-        setQueryString({
-            tab: TABS[index],
-        });
-    };
-
     useEffect(() => {
         if (p2pSettingsData?.localCurrency && filteredCurrency === '')
             setFilteredCurrency(p2pSettingsData.localCurrency);
@@ -73,8 +69,6 @@ const BuySellTable = () => {
     return (
         <div className='buy-sell-table h-full w-full relative flex flex-col'>
             <BuySellHeader
-                activeTab={activeTab}
-                setActiveTab={setActiveTab}
                 setIsFilterModalOpen={() => showModal('RadioGroupFilterModal')}
                 setSearchValue={setSearchValue}
             />

--- a/src/pages/orders/screens/OrderDetails/OrderDetails.tsx
+++ b/src/pages/orders/screens/OrderDetails/OrderDetails.tsx
@@ -47,8 +47,7 @@ const OrderDetails = () => {
 
     const onReturn = () => {
         if ((location.state as { from: string })?.from === 'Orders' || codeParam) history.push(ORDERS_URL);
-        else if ((location.state as { from: string })?.from === 'PastOrders' || orderStatusParam === 'completed')
-            history.push(`${ORDERS_URL}?tab=Past+orders`);
+        else if (orderStatusParam === 'completed') history.push(`${ORDERS_URL}?tab=Past+orders`);
         else if ((location.state as { from: string })?.from === 'BuySell') history.push(BUY_SELL_URL);
         else history.goBack();
 

--- a/src/pages/orders/screens/OrderDetails/__tests__/OrderDetails.spec.tsx
+++ b/src/pages/orders/screens/OrderDetails/__tests__/OrderDetails.spec.tsx
@@ -42,6 +42,7 @@ jest.mock('@/hooks', () => ({
             useActiveAccount: jest.fn(() => ({
                 data: {
                     currency: 'USD',
+                    loginid: '12345',
                 },
             })),
             useServerTime: jest.fn(() => ({
@@ -213,8 +214,9 @@ describe('<OrderDetails />', () => {
         expect(mockHistoryPush).toHaveBeenCalledWith('/buy-sell');
     });
 
-    it('should push to PastOrders tab if from is PastOrders', async () => {
-        mockState = { from: 'PastOrders' };
+    it('should push to PastOrders url if orderStatusParam is completed', async () => {
+        mockState = { from: '' };
+        mockSearch = '?order_status=completed';
 
         render(<OrderDetails />);
 
@@ -222,6 +224,8 @@ describe('<OrderDetails />', () => {
         await userEvent.click(backButton);
 
         expect(mockHistoryPush).toHaveBeenCalledWith('/orders?tab=Past+orders');
+
+        mockSearch = '';
     });
 
     it('should show error message if isError is true', () => {

--- a/src/pages/orders/screens/Orders/Orders.tsx
+++ b/src/pages/orders/screens/Orders/Orders.tsx
@@ -1,19 +1,19 @@
 import { useEffect, useState } from 'react';
 import moment from 'moment';
+import { useShallow } from 'zustand/react/shallow';
 import { ORDERS_STATUS } from '@/constants';
 import { api } from '@/hooks';
-import { useQueryString } from '@/hooks/custom-hooks';
+import { useTabsStore } from '@/stores';
 import { Divider, useDevice } from '@deriv-com/ui';
 import { OrdersTable } from './OrdersTable';
 import { OrdersTableHeader } from './OrdersTableHeader';
 
 const Orders = () => {
-    const { queryString } = useQueryString();
     const { isDesktop } = useDevice();
-    const currentTab = queryString.tab ?? ORDERS_STATUS.ACTIVE_ORDERS;
+    const { activeOrdersTab } = useTabsStore(useShallow(state => ({ activeOrdersTab: state.activeOrdersTab })));
     const [fromDate, setFromDate] = useState<string | null>(null);
     const [toDate, setToDate] = useState<string | null>(null);
-    const isActive = currentTab === ORDERS_STATUS.ACTIVE_ORDERS;
+    const isActive = activeOrdersTab === ORDERS_STATUS.ACTIVE_ORDERS;
 
     const {
         data = [],
@@ -34,13 +34,7 @@ const Orders = () => {
 
     return (
         <>
-            <OrdersTableHeader
-                activeTab={currentTab}
-                fromDate={fromDate}
-                setFromDate={setFromDate}
-                setToDate={setToDate}
-                toDate={toDate}
-            />
+            <OrdersTableHeader fromDate={fromDate} setFromDate={setFromDate} setToDate={setToDate} toDate={toDate} />
             {!isDesktop && <Divider />}
             <OrdersTable data={data} isActive={isActive} isLoading={isLoading} loadMoreOrders={loadMoreOrders} />
         </>

--- a/src/pages/orders/screens/Orders/OrdersTableHeader/OrdersTableHeader.tsx
+++ b/src/pages/orders/screens/Orders/OrdersTableHeader/OrdersTableHeader.tsx
@@ -1,42 +1,54 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useEffect } from 'react';
+import { useShallow } from 'zustand/react/shallow';
 import { ORDERS_STATUS } from '@/constants/orders';
 import { useQueryString } from '@/hooks/custom-hooks';
 import { OrdersDateSelection } from '@/pages/orders/components/OrdersDateSelection';
+import { useTabsStore } from '@/stores';
 import { getLocalizedTabs } from '@/utils/tabs';
 import { useTranslations } from '@deriv-com/translations';
 import { Tab, Tabs, useDevice } from '@deriv-com/ui';
 import './OrdersTableHeader.scss';
 
 type TOrdersTableHeaderProps = {
-    activeTab: string;
     fromDate: string | null;
     setFromDate: Dispatch<SetStateAction<string | null>>;
     setToDate: Dispatch<SetStateAction<string | null>>;
     toDate: string | null;
 };
 
-const OrdersTableHeader = ({ activeTab, fromDate, setFromDate, setToDate, toDate }: TOrdersTableHeaderProps) => {
+const ORDERS_TABS = [ORDERS_STATUS.ACTIVE_ORDERS, ORDERS_STATUS.PAST_ORDERS];
+
+const OrdersTableHeader = ({ fromDate, setFromDate, setToDate, toDate }: TOrdersTableHeaderProps) => {
     const { isDesktop } = useDevice();
-    const { setQueryString } = useQueryString();
+    const { queryString, setQueryString } = useQueryString();
     const { localize } = useTranslations();
+    const { activeOrdersTab, setActiveOrdersTab } = useTabsStore(
+        useShallow(state => ({ activeOrdersTab: state.activeOrdersTab, setActiveOrdersTab: state.setActiveOrdersTab }))
+    );
+
+    const setActiveTab = (index: number) => {
+        setActiveOrdersTab(ORDERS_TABS[index]);
+        setQueryString({ tab: ORDERS_TABS[index] });
+    };
+
+    useEffect(() => {
+        if (queryString.tab) setActiveOrdersTab(queryString.tab);
+        else setQueryString({ tab: activeOrdersTab });
+    }, [activeOrdersTab, queryString.tab, setActiveOrdersTab, setQueryString]);
 
     return (
         <div className='orders-table-header' data-testid='dt_orders_table_header'>
             <Tabs
                 TitleFontSize={isDesktop ? 'sm' : 'md'}
-                activeTab={getLocalizedTabs(localize)[activeTab]}
-                onChange={(index: number) =>
-                    setQueryString({
-                        tab: index === 0 ? ORDERS_STATUS.ACTIVE_ORDERS : ORDERS_STATUS.PAST_ORDERS,
-                    })
-                }
+                activeTab={getLocalizedTabs(localize)[activeOrdersTab]}
+                onChange={setActiveTab}
                 variant='primary'
                 wrapperClassName='orders-table-header__tabs'
             >
                 <Tab title={localize('Active orders')} />
                 <Tab title={localize('Past orders')} />
             </Tabs>
-            {activeTab === ORDERS_STATUS.PAST_ORDERS && (
+            {activeOrdersTab === ORDERS_STATUS.PAST_ORDERS && (
                 <OrdersDateSelection
                     fromDate={fromDate}
                     setFromDate={setFromDate}

--- a/src/pages/orders/screens/Orders/OrdersTableHeader/__tests__/OrdersTableHeader.spec.tsx
+++ b/src/pages/orders/screens/Orders/OrdersTableHeader/__tests__/OrdersTableHeader.spec.tsx
@@ -7,14 +7,27 @@ jest.mock('@deriv-com/ui', () => ({
     useDevice: () => ({ isMobile: false }),
 }));
 
-const mockFn = jest.fn();
+const mockUseQueryString = {
+    queryString: {
+        tab: 'Active orders',
+    },
+    setQueryString: jest.fn(),
+};
 jest.mock('@/hooks/custom-hooks', () => ({
     ...jest.requireActual('@/hooks/custom-hooks'),
-    useQueryString: () => ({ setQueryString: mockFn }),
+    useQueryString: jest.fn(() => mockUseQueryString),
+}));
+
+const mockTabsStore = {
+    activeOrdersTab: 'Active orders',
+    setActiveOrdersTab: jest.fn(),
+};
+
+jest.mock('@/stores', () => ({
+    useTabsStore: jest.fn(selector => (selector ? selector(mockTabsStore) : mockTabsStore)),
 }));
 
 const mockProps = {
-    activeTab: 'Active orders',
     fromDate: '2024-05-12',
     setFromDate: jest.fn(),
     setToDate: jest.fn(),
@@ -32,18 +45,30 @@ describe('OrdersTableHeader', () => {
         expect(screen.getByText('Active orders')).toBeInTheDocument();
         expect(screen.getByText('Past orders')).toBeInTheDocument();
     });
+    it('should call setActiveOrdersTab if queryString.tab has a value', () => {
+        render(<OrdersTableHeader {...mockProps} />);
+        expect(mockTabsStore.setActiveOrdersTab).toHaveBeenCalledWith('Active orders');
+    });
+    it('should call setQueryString if queryString.tab is empty', () => {
+        mockUseQueryString.queryString.tab = '';
+        render(<OrdersTableHeader {...mockProps} />);
+        expect(mockUseQueryString.setQueryString).toHaveBeenCalledWith({ tab: 'Active orders' });
+    });
     it('should handle clicking on tabs', async () => {
         render(<OrdersTableHeader {...mockProps} />);
         const pastOrdersTab = screen.getByText('Past orders');
         expect(pastOrdersTab).toBeInTheDocument();
         await userEvent.click(pastOrdersTab);
-        expect(mockFn).toHaveBeenCalledWith({ tab: 'Past orders' });
+        expect(mockTabsStore.setActiveOrdersTab).toHaveBeenCalled();
+        expect(mockUseQueryString.setQueryString).toHaveBeenCalled();
     });
     it('should render OrdersDateSelection when user is on Past orders tab', () => {
-        render(<OrdersTableHeader {...mockProps} activeTab='Past orders' />);
+        mockTabsStore.activeOrdersTab = 'Past orders';
+        render(<OrdersTableHeader {...mockProps} />);
         expect(screen.getByText('OrdersDateSelection')).toBeInTheDocument();
     });
     it('should not render OrdersDateSelection when user is on Active orders tab', () => {
+        mockTabsStore.activeOrdersTab = 'Active orders';
         render(<OrdersTableHeader {...mockProps} />);
         expect(screen.queryByText('OrdersDateSelection')).not.toBeInTheDocument();
     });

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,1 +1,2 @@
 export { default as useBuySellFiltersStore } from './useBuySellFiltersStore';
+export { default as useTabsStore } from './useTabsStore';

--- a/src/stores/useTabsStore.ts
+++ b/src/stores/useTabsStore.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import { ADVERT_TYPE, ORDERS_STATUS } from '@/constants';
+
+type TTabsState = {
+    activeAdvertisersBuySellTab: string;
+    activeBuySellTab: string;
+    activeOrdersTab: string;
+};
+
+type TTabsAction = {
+    setActiveAdvertisersBuySellTab: (activeAdvertisersBuySellTab: string) => void;
+    setActiveBuySellTab: (activeBuySellTab: string) => void;
+    setActiveOrdersTab: (activeOrdersTab: string) => void;
+};
+
+const useTabsStore = create<TTabsAction & TTabsState>()(set => ({
+    activeAdvertisersBuySellTab: ADVERT_TYPE.BUY,
+    activeBuySellTab: ADVERT_TYPE.BUY,
+    activeOrdersTab: ORDERS_STATUS.ACTIVE_ORDERS,
+    setActiveAdvertisersBuySellTab: activeAdvertisersBuySellTab => set({ activeAdvertisersBuySellTab }),
+    setActiveBuySellTab: activeBuySellTab => set({ activeBuySellTab }),
+    setActiveOrdersTab: activeOrdersTab => set({ activeOrdersTab }),
+}));
+
+export default useTabsStore;


### PR DESCRIPTION
- Added new store to handle the keeping the tab state throughout the user session
- Added for Buy/Sell, Orders and Advertisers page.
- Updated test cases where the component uses the stores

![Screenshot 2024-07-11 at 10 23 16 AM](https://github.com/deriv-com/p2p/assets/103412909/db6cbe4b-83e5-4b11-9685-65b1c3202e84)
![Screenshot 2024-07-11 at 10 30 54 AM](https://github.com/deriv-com/p2p/assets/103412909/c5e3cb92-2dfc-4655-a17d-330a80e09b4d)
![Screenshot 2024-07-11 at 10 37 54 AM](https://github.com/deriv-com/p2p/assets/103412909/8580affe-0fd6-4633-aa91-939a27af8f33)
![Screenshot 2024-07-11 at 10 50 50 AM](https://github.com/deriv-com/p2p/assets/103412909/fd86c28c-615d-4357-a299-f0f689f46bdb)
![Screenshot 2024-07-11 at 11 21 29 AM](https://github.com/deriv-com/p2p/assets/103412909/02617747-b2c9-4c40-8951-937517bea0c2)

https://github.com/deriv-com/p2p/assets/103412909/07aaef3a-59be-4008-88ec-618c89db9826


