### PR TITLE
feat: added page_load and allow_tracking events for gtm

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -3,6 +3,9 @@ declare global {
         LC_API: {
             open_chat_window: VoidFunction;
         };
+        dataLayer: {
+            push: (event: { [key: string]: boolean | number | string; event: string }) => void;
+        };
     }
 }
 

--- a/src/hooks/custom-hooks/__tests__/useHandleRouteChange.spec.ts
+++ b/src/hooks/custom-hooks/__tests__/useHandleRouteChange.spec.ts
@@ -1,0 +1,28 @@
+import { useLocation } from 'react-router-dom';
+import { renderHook } from '@testing-library/react';
+import useHandleRouteChange from '../useHandleRouteChange';
+
+jest.mock('react-router-dom', () => ({
+    useLocation: jest.fn(),
+}));
+
+describe('useHandleRouteChange', () => {
+    beforeEach(() => {
+        (useLocation as jest.Mock).mockReset();
+        window.dataLayer = [] as { [key: string]: boolean | number | string; event: string }[];
+    });
+
+    it('should push event to dataLayer on location change', () => {
+        (useLocation as jest.Mock).mockReturnValue({ pathname: '/initial' });
+
+        renderHook(() => useHandleRouteChange());
+
+        expect(window.dataLayer).toEqual([{ event: 'page_load' }]);
+
+        (useLocation as jest.Mock).mockReturnValue({ pathname: '/new-path' });
+
+        renderHook(() => useHandleRouteChange());
+
+        expect(window.dataLayer).toEqual([{ event: 'page_load' }, { event: 'page_load' }]);
+    });
+});

--- a/src/hooks/custom-hooks/index.ts
+++ b/src/hooks/custom-hooks/index.ts
@@ -4,6 +4,7 @@ export { default as useExtendedOrderDetails } from './useExtendedOrderDetails';
 export { default as useFetchMore } from './useFetchMore';
 export { default as useFloatingRate } from './useFloatingRate';
 export { default as useFullScreen } from './useFullScreen';
+export { default as useHandleRouteChange } from './useHandleRouteChange';
 export { default as useIsAdvertiser } from './useIsAdvertiser';
 export { default as useIsAdvertiserBarred } from './useIsAdvertiserBarred';
 export { default as useIsP2PBlocked } from './useIsP2PBlocked';

--- a/src/hooks/custom-hooks/useHandleRouteChange.ts
+++ b/src/hooks/custom-hooks/useHandleRouteChange.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const useHandleRouteChange = () => {
+    const location = useLocation();
+    useEffect(() => {
+        window?.dataLayer.push({
+            event: 'page_load',
+        });
+    }, [location]);
+};
+
+export default useHandleRouteChange;

--- a/src/hooks/custom-hooks/useHandleRouteChange.ts
+++ b/src/hooks/custom-hooks/useHandleRouteChange.ts
@@ -1,6 +1,9 @@
 import { useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 
+/**
+ * Custom hook to handle side effects on route change like pushing events to dataLayer.
+ */
 const useHandleRouteChange = () => {
     const location = useLocation();
     useEffect(() => {

--- a/src/routes/AppContent/index.tsx
+++ b/src/routes/AppContent/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
 import { BlockedScenarios } from '@/components/BlockedScenarios';
 import { BUY_SELL_URL, ERROR_CODES } from '@/constants';
@@ -20,7 +20,7 @@ const tabRoutesConfiguration = routes.filter(
 );
 
 const AppContent = () => {
-    const [isGtmTracking, setIsGtmTracking] = useState(false);
+    const isGtmTracking = useRef(false);
     const history = useHistory();
     const location = useLocation();
     const { isDesktop } = useDevice();
@@ -72,11 +72,11 @@ const AppContent = () => {
     }, [location]);
 
     useEffect(() => {
-        if (!isGtmTracking) {
+        if (!isGtmTracking.current) {
             window.dataLayer.push({ event: 'allow_tracking' });
-            setIsGtmTracking(true);
+            isGtmTracking.current = true;
         }
-    }, [isGtmTracking]);
+    }, []);
 
     const getComponent = () => {
         if ((isLoadingActiveAccount || !isFetched || !activeAccountData) && !isEndpointRoute) {

--- a/src/routes/AppContent/index.tsx
+++ b/src/routes/AppContent/index.tsx
@@ -20,6 +20,7 @@ const tabRoutesConfiguration = routes.filter(
 );
 
 const AppContent = () => {
+    const [isGtmTracking, setIsGtmTracking] = useState(false);
     const history = useHistory();
     const location = useLocation();
     const { isDesktop } = useDevice();
@@ -69,6 +70,13 @@ const AppContent = () => {
     useEffect(() => {
         setActiveTab(getActiveTab(location.pathname));
     }, [location]);
+
+    useEffect(() => {
+        if (!isGtmTracking) {
+            window.dataLayer.push({ event: 'allow_tracking' });
+            setIsGtmTracking(true);
+        }
+    }, [isGtmTracking]);
 
     const getComponent = () => {
         if ((isLoadingActiveAccount || !isFetched || !activeAccountData) && !isEndpointRoute) {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,5 +1,5 @@
-import { FC, Suspense } from 'react';
-import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
+import { FC, Suspense, useEffect } from 'react';
+import { Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom';
 import { TCurrency } from 'types';
 import { Page404 } from '@/components';
 import { BUY_SELL_URL } from '@/constants';
@@ -7,7 +7,6 @@ import { Loader } from '@deriv-com/ui';
 import { routes } from './routes-config';
 
 type TState = { [key: string]: string[] | TCurrency | string; from: string };
-
 declare module 'react-router-dom' {
     export function useHistory(): {
         goBack: () => void;
@@ -36,6 +35,12 @@ const RouteWithSubRoutes = (route: TRoutesWithSubRoutes) => {
 };
 
 const Router: FC = () => {
+    const location = useLocation();
+    useEffect(() => {
+        window.dataLayer.push({
+            event: 'page_load',
+        });
+    }, [location]);
     return (
         <Suspense fallback={<Loader isFullScreen />}>
             <Switch>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -36,7 +36,6 @@ const RouteWithSubRoutes = (route: TRoutesWithSubRoutes) => {
 };
 
 const Router: FC = () => {
-    // this hook will handle side effects on route change like pushing page_load event to dataLayer
     useHandleRouteChange();
     return (
         <Suspense fallback={<Loader isFullScreen />}>

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -1,8 +1,9 @@
-import { FC, Suspense, useEffect } from 'react';
-import { Redirect, Route, RouteComponentProps, Switch, useLocation } from 'react-router-dom';
+import { FC, Suspense } from 'react';
+import { Redirect, Route, RouteComponentProps, Switch } from 'react-router-dom';
 import { TCurrency } from 'types';
 import { Page404 } from '@/components';
 import { BUY_SELL_URL } from '@/constants';
+import { useHandleRouteChange } from '@/hooks';
 import { Loader } from '@deriv-com/ui';
 import { routes } from './routes-config';
 
@@ -35,12 +36,8 @@ const RouteWithSubRoutes = (route: TRoutesWithSubRoutes) => {
 };
 
 const Router: FC = () => {
-    const location = useLocation();
-    useEffect(() => {
-        window.dataLayer.push({
-            event: 'page_load',
-        });
-    }, [location]);
+    // this hook will handle side effects on route change like pushing page_load event to dataLayer
+    useHandleRouteChange();
     return (
         <Suspense fallback={<Loader isFullScreen />}>
             <Switch>


### PR DESCRIPTION
## changes
- added the logic to send `page_load` and `allow_tracking` events to gtm so that core-web-vitals and google-analytics get triggered on p2p 