### PR TITLE
Added script for UTM initialisation

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,9 @@
         <meta name="keywords" content="p2p, buy, sell" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Buy and sell on Deriv P2P to fund your trading account | Deriv</title>
+        <!-- Start Cookies script -->
+        <script src="https://static.deriv.com/scripts/cookie.js" async></script>
+        <!-- End Cookies script -->
         <!-- Google Tag Manager -->
         <script>
             (function (w, d, s, l, i) {


### PR DESCRIPTION
Integrated script to initalise UTM data for marketing analytics

Tested with `http://localhost:5174/buy-sell?utm_source=adroll&utm_medium=ppc-display&utm_campaign=CCC&utm_campaign_id=DDD&utm_adgroup_id=EEE&signup_device=desktop`:
<img width="1584" alt="Screenshot 2024-07-29 at 11 32 06 AM" src="https://github.com/user-attachments/assets/bc5e4d5a-73ee-4853-92af-b36f1bd8b790">


Tested with `http://localhost:5174/buy-sell?t=test&utm_source=AAA&utm_medium=BBB&utm_campaign=CCC`:
<img width="984" alt="Screenshot 2024-07-29 at 11 30 21 AM" src="https://github.com/user-attachments/assets/ed578b13-7cca-40dd-ac3e-fbaefcf162a0">
<img width="656" alt="Screenshot 2024-07-29 at 11 30 14 AM" src="https://github.com/user-attachments/assets/e3c801bc-d31b-43a9-8845-c523d04c3ca7">
