### PR TITLE
chore/amam/ignore environment file in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,11 @@ npm-debug.log
 lerna-debug.log
 coverage
 
+# Ensure environment files is not being committed
 .env
-.env.local
+.env.*
+*.env
+
 *.secret
 nx-cloud.env
 test-results/


### PR DESCRIPTION
All of FE repositories are public, and during testing, .env files are prone to be pushed or committed accidentally and leak some credentials to the public

Add/update .gitignore files with the following
- .env
- .env.*
- *.env

this will cover most of the use cases to not accidentally add credentials to the commit repository