### PR TITLE
Ameerul / FEQ-2533 Once Adding nickname on clicking `Buy/Sell` USD or `Create Ad` button does not redirected to respective forms

### DIFF
--- a/src/components/AdvertsTableRow/AdvertsTableRow.tsx
+++ b/src/components/AdvertsTableRow/AdvertsTableRow.tsx
@@ -89,7 +89,7 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
             showModal('BuySellForm');
             setSelectedAdvertId(undefined);
         }
-    }, [advertId, hasCreatedAdvertiser, hideModal, isModalOpenFor, selectedAdvertId, showModal]);
+    }, [advertId, hasCreatedAdvertiser, isModalOpenFor, selectedAdvertId, showModal]);
 
     return (
         <div

--- a/src/components/AdvertsTableRow/AdvertsTableRow.tsx
+++ b/src/components/AdvertsTableRow/AdvertsTableRow.tsx
@@ -1,4 +1,4 @@
-import { Fragment, memo } from 'react';
+import { Fragment, memo, useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { useHistory, useLocation } from 'react-router-dom';
 import { TAdvertsTableRowRenderer, TCurrency } from 'types';
@@ -7,6 +7,7 @@ import { ErrorModal, NicknameModal } from '@/components/Modals';
 import { ADVERTISER_URL, BUY_SELL } from '@/constants';
 import { api } from '@/hooks';
 import { useIsAdvertiser, useIsAdvertiserBarred, useModalManager, usePoiPoaStatus } from '@/hooks/custom-hooks';
+import { useAdvertiserInfoState } from '@/providers/AdvertiserInfoStateProvider';
 import { generateEffectiveRate, getCurrentRoute, getEligibilityErrorMessage } from '@/utils';
 import { LabelPairedChevronRightMdRegularIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
@@ -14,6 +15,7 @@ import { Button, Text, useDevice } from '@deriv-com/ui';
 import './AdvertsTableRow.scss';
 
 const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
+    const [selectedAdvertId, setSelectedAdvertId] = useState<string | undefined>(undefined);
     const { hideModal, isModalOpenFor, showModal } = useModalManager();
     const { isDesktop, isTablet } = useDevice();
     const history = useHistory();
@@ -25,6 +27,7 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
     const { data: poiPoaData } = usePoiPoaStatus();
     const { isPoaVerified, isPoiVerified } = poiPoaData || {};
     const { localize } = useTranslations();
+    const { hasCreatedAdvertiser } = useAdvertiserInfoState();
 
     const {
         account_currency: accountCurrency,
@@ -79,6 +82,14 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
     const redirectToAdvertiser = () => {
         isAdvertiserBarred ? undefined : history.push(`${ADVERTISER_URL}/${id}?currency=${localCurrency}`);
     };
+
+    useEffect(() => {
+        // If the user has become an advertiser, open the BuySellForm modal specifically for the selected advert.
+        if (hasCreatedAdvertiser && !isModalOpenFor('BuySellForm') && selectedAdvertId === advertId) {
+            showModal('BuySellForm');
+            setSelectedAdvertId(undefined);
+        }
+    }, [advertId, hasCreatedAdvertiser, hideModal, isModalOpenFor, selectedAdvertId, showModal]);
 
     return (
         <div
@@ -202,6 +213,7 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
                                     searchParams.set('poi_poa_verified', 'false');
                                     history.replace({ pathname: location.pathname, search: searchParams.toString() });
                                 } else {
+                                    if (!isAdvertiser) setSelectedAdvertId(advertId);
                                     showModal(isAdvertiser ? 'BuySellForm' : 'NicknameModal');
                                 }
                             }}

--- a/src/components/Modals/NicknameModal/NicknameModal.tsx
+++ b/src/components/Modals/NicknameModal/NicknameModal.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import debounce from 'lodash/debounce';
 import { Controller, useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
-import { BUY_SELL_URL } from '@/constants';
+import { BUY_SELL_URL, MY_ADS_URL } from '@/constants';
 import { api } from '@/hooks';
 import { useAdvertiserInfoState } from '@/providers/AdvertiserInfoStateProvider';
 import { getCurrentRoute } from '@/utils';
@@ -46,6 +46,7 @@ const NicknameModal = ({ isModalOpen, onRequestClose }: TNicknameModalProps) => 
         if (isSuccess) {
             onRequestClose();
             setHasCreatedAdvertiser(true);
+            if (currentRoute === 'my-ads') history.push(`${MY_ADS_URL}/adForm?formAction=create`);
         } else if (isError) {
             debouncedReset();
         }

--- a/src/hooks/api/settings/p2p-settings/useSettings.ts
+++ b/src/hooks/api/settings/p2p-settings/useSettings.ts
@@ -99,6 +99,7 @@ const useSettings = () => {
     return {
         ...rest,
         data: p2pSettings,
+        setP2PSettings,
     };
 };
 

--- a/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.scss
+++ b/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.scss
@@ -19,4 +19,10 @@
             overflow: auto;
         }
     }
+
+    & .mobile-wrapper {
+        @include mobile {
+            height: calc(100% - 3.5rem);
+        }
+    }
 }

--- a/src/pages/buy-sell/screens/BuySellTable/__tests__/BuySellTable.spec.tsx
+++ b/src/pages/buy-sell/screens/BuySellTable/__tests__/BuySellTable.spec.tsx
@@ -1,4 +1,5 @@
 import { usePoiPoaStatus } from '@/hooks/custom-hooks';
+import { useAdvertiserInfoState } from '@/providers/AdvertiserInfoStateProvider';
 import { useDevice } from '@deriv-com/ui';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -99,6 +100,12 @@ jest.mock('@/hooks/custom-hooks', () => ({
     useQueryString: jest.fn(() => mockUseQueryString),
 }));
 
+jest.mock('@/providers/AdvertiserInfoStateProvider', () => ({
+    useAdvertiserInfoState: jest.fn().mockReturnValue({
+        hasCreatedAdvertiser: jest.fn(),
+    }),
+}));
+
 jest.mock('@deriv-com/ui', () => ({
     ...jest.requireActual('@deriv-com/ui'),
     useDevice: jest.fn(() => ({ isDesktop: true, isTablet: false })),
@@ -106,6 +113,7 @@ jest.mock('@deriv-com/ui', () => ({
 
 const mockUseDevice = useDevice as jest.Mock;
 const mockUsePoiPoaStatus = usePoiPoaStatus as jest.Mock;
+const mockUseAdvertiserInfoState = useAdvertiserInfoState as jest.MockedFunction<typeof useAdvertiserInfoState>;
 
 describe('<BuySellTable />', () => {
     beforeEach(() => {
@@ -197,6 +205,17 @@ describe('<BuySellTable />', () => {
         await userEvent.click(buyButton);
 
         expect(screen.getByText('NicknameModal')).toBeInTheDocument();
+    });
+
+    it('should call showModal with BuySellForm if hasCreatedAdvertiser is true and user is not an advertiser', async () => {
+        mockUseIsAdvertiser = false;
+        (mockUseAdvertiserInfoState as jest.Mock).mockReturnValue({
+            hasCreatedAdvertiser: true,
+        });
+
+        render(<BuySellTable />);
+
+        expect(mockUseModalManager.showModal).toHaveBeenCalledWith('BuySellForm');
     });
 
     it('should not render render the BuySellForm when the user clicks on Buy/Sell button and the user is an advertiser', async () => {

--- a/src/providers/AdvertiserInfoStateProvider/AdvertiserInfoStateProvider.tsx
+++ b/src/providers/AdvertiserInfoStateProvider/AdvertiserInfoStateProvider.tsx
@@ -2,6 +2,7 @@ import { createContext, PropsWithChildren, useContext } from 'react';
 
 type TContextValue = {
     error: { code: string; message: string } | undefined;
+    hasCreatedAdvertiser: boolean;
     isIdle: boolean;
     isLoading: boolean;
     isSubscribed: boolean;

--- a/src/routes/AppContent/index.tsx
+++ b/src/routes/AppContent/index.tsx
@@ -38,7 +38,12 @@ const AppContent = () => {
 
     const [activeTab, setActiveTab] = useState(() => getActiveTab(location.pathname));
     const [hasCreatedAdvertiser, setHasCreatedAdvertiser] = useState(false);
-    const { isActive, subscribe: subscribeP2PSettings } = api.settings.useSettings();
+    const {
+        isActive,
+        isLoading: isP2PSettingsLoading,
+        setP2PSettings,
+        subscribe: subscribeP2PSettings,
+    } = api.settings.useSettings();
     const {
         error,
         isActive: isSubscribed,
@@ -57,7 +62,9 @@ const AppContent = () => {
         if (activeAccountData) {
             subscribeP2PSettings({});
         }
-
+        return () => {
+            setP2PSettings({});
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeAccountData]);
 
@@ -88,7 +95,7 @@ const AppContent = () => {
     }, []);
 
     const getComponent = () => {
-        if ((isLoadingActiveAccount || !isFetched || !activeAccountData) && !isEndpointRoute) {
+        if ((isP2PSettingsLoading || isLoadingActiveAccount || !isFetched || !activeAccountData) && !isEndpointRoute) {
             return <Loader />;
         } else if ((isP2PBlocked && !isEndpointRoute) || isPermissionDenied) {
             return <BlockedScenarios type={status} />;
@@ -121,6 +128,7 @@ const AppContent = () => {
         <AdvertiserInfoStateProvider
             value={{
                 error,
+                hasCreatedAdvertiser,
                 isIdle,
                 isLoading,
                 isSubscribed,

--- a/src/routes/routes-config.ts
+++ b/src/routes/routes-config.ts
@@ -50,9 +50,9 @@ export const getRoutes = (localize: TLocalize) => [
     },
     {
         component: MyProfile,
-        name: 'My Profile',
+        name: 'My profile',
         path: MY_PROFILE_URL,
-        text: localize('My Profile'),
+        text: localize('My profile'),
     },
     {
         component: Advertiser,


### PR DESCRIPTION
- Added hasCreatedAdvertiser value to Provider to know when the user has become an advertiser inside of AdvertsTableRow
- Added logic to show the BuySellForm after user has become an advertiser in Buy/Sell page and Advertiser page
- Exposed setP2PSettings here as well as this will fix the issue when non p2p but authenticated user logs in, and they click on Buy/Sell USD button, it wouldve shown the BuySellForm.
- Updated height for BuySellForm in advertiser page as it was a bit short
- Updated test cases for BuySellTable

### Before:

https://github.com/user-attachments/assets/ba71d006-58c0-4d8c-99fe-693b0ec8346c

![Screenshot 2024-08-06 at 3 10 55 PM](https://github.com/user-attachments/assets/a7f43c5c-e770-4f60-b1de-2b8bb7f0a237)

### After:

https://github.com/user-attachments/assets/254c37c0-5dbf-4b4b-b800-619d219adac4


https://github.com/user-attachments/assets/3cd40e73-8f45-4a0d-ab8c-95f7fd54f72f


https://github.com/user-attachments/assets/be5d67ff-f393-40d2-8f8f-0e37ad44fc23


https://github.com/user-attachments/assets/76c388ea-01fb-413c-9377-9b4811272a44


https://github.com/user-attachments/assets/269fff47-a01e-4186-9337-e678a8ad5593


