### PR TITLE
Ameerul / FEQ-2572 Multiple APIs are being called when scrolling to the end of the buy/sell and orders list

### DIFF
--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -10,7 +10,6 @@ type TProps<T> = {
     data: T[];
     emptyDataMessage?: string;
     groupBy?: GroupingState;
-    isFetching: boolean;
     loadMoreFunction: () => void;
     renderHeader?: (data: string) => JSX.Element;
     rowRender: (data: T) => JSX.Element;

--- a/src/hooks/api/advert/p2p-advert/useAdvertList.ts
+++ b/src/hooks/api/advert/p2p-advert/useAdvertList.ts
@@ -5,8 +5,9 @@ type TPayload = NonNullable<Parameters<typeof useP2PAdvertList>[0]>['payload'];
 /**
  * This custom hook returns available adverts for use with 'p2p_order_create' by calling 'p2p_advert_list' endpoint
  */
-const useAdvertList = (payload?: TPayload) => {
+const useAdvertList = (payload?: TPayload, enabled = true) => {
     const { data, loadMoreAdverts, ...rest } = useP2PAdvertList({
+        enabled,
         payload: { ...payload, limit: payload?.limit, offset: payload?.offset },
         queryKey: ['p2p_advert_list', payload],
     });

--- a/src/hooks/custom-hooks/useFetchMore.ts
+++ b/src/hooks/custom-hooks/useFetchMore.ts
@@ -1,4 +1,5 @@
 import { RefObject, useCallback, useEffect } from 'react';
+import debounce from 'lodash/debounce';
 
 type TProps = {
     loadMore: () => void;
@@ -7,20 +8,21 @@ type TProps = {
 
 /** A custom hook to load more items in the table on scroll to bottom of the table */
 const useFetchMore = ({ loadMore, ref }: TProps) => {
+    const debouncedLoadMore = debounce(loadMore, 100);
     //called on scroll and possibly on mount to fetch more data as the user scrolls and reaches bottom of table
     const fetchMoreOnBottomReached = useCallback(
         (containerRefElement?: HTMLDivElement | null) => {
             if (containerRefElement) {
                 const { clientHeight, scrollHeight, scrollTop } = containerRefElement;
                 //once the user has scrolled within 200px of the bottom of the table, fetch more data if we can
-                const isBottom = scrollHeight - scrollTop <= clientHeight + 200;
+                const isBottom = scrollHeight - scrollTop - clientHeight < 200;
 
                 if (isBottom) {
-                    loadMore();
+                    debouncedLoadMore();
                 }
             }
         },
-        [loadMore]
+        [debouncedLoadMore]
     );
 
     useEffect(() => {

--- a/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.tsx
+++ b/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.tsx
@@ -39,7 +39,7 @@ const AdvertiserAdvertsTable = ({ advertiserId }: TAdvertiserAdvertsTableProps) 
         }))
     );
     const { data: advertInfo, error, isLoading: isLoadingAdvert } = api.advert.useGet({ id: advertId }, !!advertId);
-    const { data, isFetching, isLoading, loadMoreAdverts } = api.advert.useGetList({
+    const { data, isLoading, loadMoreAdverts } = api.advert.useGetList({
         advertiser_id: advertiserId,
         counterparty_type: activeAdvertisersBuySellTab === ADVERT_TYPE.BUY ? BUY_SELL.BUY : BUY_SELL.SELL,
         local_currency: currency,
@@ -101,12 +101,7 @@ const AdvertiserAdvertsTable = ({ advertiserId }: TAdvertiserAdvertsTableProps) 
                 <Tab className='text-xs' title={localize('Buy')} />
                 <Tab title={localize('Sell')} />
             </Tabs>
-            <AdvertsTableRenderer
-                data={data}
-                isFetching={isFetching}
-                isLoading={isLoading}
-                loadMoreAdverts={loadMoreAdverts}
-            />
+            <AdvertsTableRenderer data={data} isLoading={isLoading} loadMoreAdverts={loadMoreAdverts} />
             {isModalOpenFor('BuySellForm') && (
                 <BuySellForm advertId={advertId} isModalOpen onRequestClose={hideModal} />
             )}

--- a/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertsTableRenderer/AdvertsTableRenderer.tsx
+++ b/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertsTableRenderer/AdvertsTableRenderer.tsx
@@ -14,12 +14,11 @@ const headerRenderer = (header: string) => <span>{header}</span>;
 
 type TAdvertsTableRenderer = {
     data?: TAdvertsTableRowRenderer[];
-    isFetching: boolean;
     isLoading: boolean;
     loadMoreAdverts: () => void;
 };
 
-const AdvertsTableRenderer = ({ data, isFetching, isLoading, loadMoreAdverts }: TAdvertsTableRenderer) => {
+const AdvertsTableRenderer = ({ data, isLoading, loadMoreAdverts }: TAdvertsTableRenderer) => {
     const { localize } = useTranslations();
     if (isLoading) {
         return <Loader className='relative mt-40 top-0' />;
@@ -44,7 +43,6 @@ const AdvertsTableRenderer = ({ data, isFetching, isLoading, loadMoreAdverts }: 
             columns={getColumns(localize)}
             data={data}
             emptyDataMessage={localize('There are no matching ads.')}
-            isFetching={isFetching}
             loadMoreFunction={loadMoreAdverts}
             renderHeader={headerRenderer}
             rowRender={(data: unknown) => <AdvertsTableRow {...(data as TAdvertsTableRowRenderer)} />}

--- a/src/pages/buy-sell/screens/BuySellTable/BuySellTable.tsx
+++ b/src/pages/buy-sell/screens/BuySellTable/BuySellTable.tsx
@@ -44,17 +44,19 @@ const BuySellTable = () => {
 
     const {
         data,
-        isFetching,
         isPending: isLoading,
         loadMoreAdverts,
-    } = api.advert.useGetList({
-        advertiser_name: searchValue,
-        counterparty_type: activeBuySellTab === ADVERT_TYPE.BUY ? BUY_SELL.BUY : BUY_SELL.SELL,
-        local_currency: filteredCurrency,
-        payment_method: selectedPaymentMethods.length > 0 ? selectedPaymentMethods : undefined,
-        sort_by: sortByValue,
-        use_client_limits: shouldUseClientLimits ? 1 : 0,
-    });
+    } = api.advert.useGetList(
+        {
+            advertiser_name: searchValue,
+            counterparty_type: activeBuySellTab === ADVERT_TYPE.BUY ? BUY_SELL.BUY : BUY_SELL.SELL,
+            local_currency: filteredCurrency,
+            payment_method: selectedPaymentMethods.length > 0 ? selectedPaymentMethods : undefined,
+            sort_by: sortByValue,
+            use_client_limits: shouldUseClientLimits ? 1 : 0,
+        },
+        !!filteredCurrency
+    );
 
     const onToggle = (value: string) => {
         setSortByValue(value as TSortByValues);
@@ -74,7 +76,6 @@ const BuySellTable = () => {
             />
             <BuySellTableRenderer
                 data={data}
-                isFetching={isFetching}
                 isLoading={isLoading}
                 loadMoreAdverts={loadMoreAdverts}
                 searchValue={searchValue}

--- a/src/pages/buy-sell/screens/BuySellTable/BuySellTableRenderer/BuySellTableRenderer.tsx
+++ b/src/pages/buy-sell/screens/BuySellTable/BuySellTableRenderer/BuySellTableRenderer.tsx
@@ -18,7 +18,6 @@ const getColumns = (localize: TLocalize) => [
 
 type TBuySellTableRowRendererProps = {
     data?: TAdvertsTableRowRenderer[];
-    isFetching: boolean;
     isLoading: boolean;
     loadMoreAdverts: () => void;
     searchValue: string;
@@ -26,7 +25,6 @@ type TBuySellTableRowRendererProps = {
 
 const BuySellTableRenderer = ({
     data = [],
-    isFetching,
     isLoading,
     loadMoreAdverts,
     searchValue,
@@ -36,7 +34,7 @@ const BuySellTableRenderer = ({
     const history = useHistory();
 
     if (isLoading) {
-        return <Loader className='mt-80' />;
+        return <Loader />;
     }
 
     if ((!data && !searchValue) || (data.length === 0 && !searchValue)) {
@@ -69,7 +67,6 @@ const BuySellTableRenderer = ({
             columns={getColumns(localize)}
             data={data}
             emptyDataMessage={localize('There are no matching ads.')}
-            isFetching={isFetching}
             loadMoreFunction={loadMoreAdverts}
             renderHeader={headerRenderer}
             rowRender={(data: unknown) => <AdvertsTableRow {...(data as TAdvertsTableRowRenderer)} />}

--- a/src/pages/my-ads/screens/MyAds/MyAdsTable/MyAdsTable.tsx
+++ b/src/pages/my-ads/screens/MyAds/MyAdsTable/MyAdsTable.tsx
@@ -72,7 +72,6 @@ const MyAdsTable = () => {
                 <Table
                     columns={getColumns(localize)}
                     data={data}
-                    isFetching={isFetching}
                     loadMoreFunction={loadMoreAdverts}
                     renderHeader={headerRenderer}
                     rowRender={(rowData: unknown) => (

--- a/src/pages/my-profile/screens/MyProfile/MyProfile.scss
+++ b/src/pages/my-profile/screens/MyProfile/MyProfile.scss
@@ -3,11 +3,11 @@
     flex-direction: column;
     padding-top: 2.4rem;
     overflow-y: auto;
-    height: calc(100% - 12rem);
+    max-height: calc(100% - 9rem);
 
     @include mobile-or-tablet-screen {
         padding: 0;
-        height: calc(100% - 11rem);
+        max-height: calc(100% - 11rem);
     }
 
     &__tabs {

--- a/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.scss
+++ b/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.scss
@@ -2,8 +2,7 @@
     max-height: 22.4rem;
 
     @include mobile-or-tablet-screen {
-        height: calc(100vh - 29.5rem);
-        max-height: 100%;
+        max-height: calc(100vh - 29.5rem);
     }
 
     &__row {

--- a/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.scss
+++ b/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.scss
@@ -1,15 +1,9 @@
 .my-profile-counterparties-table {
-    & .deriv-table__content {
-        max-height: 22.4rem;
+    max-height: 22.4rem;
 
-        @include mobile-or-tablet-screen {
-            height: calc(100vh - 29.5rem);
-            max-height: 100%;
-        }
-
-        &__row {
-            border-bottom: 1px solid #f2f3f4;
-        }
+    @include mobile-or-tablet-screen {
+        height: calc(100vh - 29.5rem);
+        max-height: 100%;
     }
 
     &__row {

--- a/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.tsx
+++ b/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/MyProfileCounterpartiesTable.tsx
@@ -1,8 +1,9 @@
 import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { Table } from '@/components';
 import { api } from '@/hooks';
 import { DerivLightIcBlockedAdvertisersBarredIcon } from '@deriv/quill-icons';
 import { Localize } from '@deriv-com/translations';
-import { Loader, Table, Text, useDevice } from '@deriv-com/ui';
+import { Loader, Text, useDevice } from '@deriv-com/ui';
 import { MyProfileCounterpartiesEmpty } from '../MyProfileCounterpartiesEmpty';
 import { MyProfileCounterpartiesTableRow } from '../MyProfileCounterpartiesTableRow';
 import './MyProfileCounterpartiesTable.scss';

--- a/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/__tests__/MyProfileCounterpartiesTable.spec.tsx
+++ b/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTable/__tests__/MyProfileCounterpartiesTable.spec.tsx
@@ -35,6 +35,7 @@ const mockUseModalManager = {
 };
 
 jest.mock('@/hooks/custom-hooks', () => ({
+    ...jest.requireActual('@/hooks/custom-hooks'),
     useIsAdvertiserBarred: jest.fn(() => false),
     useModalManager: jest.fn(() => mockUseModalManager),
 }));

--- a/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTableRow/MyProfileCounterpartiesTableRow.scss
+++ b/src/pages/my-profile/screens/MyProfileCounterparties/MyProfileCounterpartiesTableRow/MyProfileCounterpartiesTableRow.scss
@@ -2,6 +2,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    padding: 1.6rem;
 
     &:hover {
         background: #e6e9e9;

--- a/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.scss
+++ b/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.scss
@@ -1,5 +1,5 @@
 .orders-table {
-    & .deriv-table {
+    & .table {
         &__header {
             grid-template-columns: 1fr 1.5fr 2fr 3fr 1.5fr 1.5fr 1.5fr;
         }
@@ -19,7 +19,7 @@
     }
 
     &--inactive {
-        & .deriv-table__header {
+        & .table__header {
             grid-template-columns: 2fr 1fr 1.5fr 2fr 3fr 1.5fr 1.5fr 2fr;
             gap: 1rem;
         }

--- a/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.scss
+++ b/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.scss
@@ -19,9 +19,17 @@
     }
 
     &--inactive {
-        & .table__header {
-            grid-template-columns: 2fr 1fr 1.5fr 2fr 3fr 1.5fr 1.5fr 2fr;
-            gap: 1rem;
+        & .table {
+            &__header {
+                grid-template-columns: 2fr 1fr 1.5fr 2fr 3fr 1.5fr 1.5fr 2fr;
+                gap: 1rem;
+            }
+
+            &__content {
+                @include mobile-or-tablet-screen {
+                    height: calc(100vh - 25rem) !important;
+                }
+            }
         }
     }
 }

--- a/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.tsx
+++ b/src/pages/orders/screens/Orders/OrdersTable/OrdersTable.tsx
@@ -1,8 +1,9 @@
 import { memo } from 'react';
 import clsx from 'clsx';
 import { THooks, TLocalize } from 'types';
+import { Table } from '@/components';
 import { useTranslations } from '@deriv-com/translations';
-import { Loader, Table, useDevice } from '@deriv-com/ui';
+import { Loader, useDevice } from '@deriv-com/ui';
 import { OrdersEmpty } from '../OrdersEmpty';
 import { OrdersTableRow } from '../OrdersTableRow';
 import './OrdersTable.scss';
@@ -65,6 +66,7 @@ const OrdersTable = ({ data, isActive, isLoading, loadMoreOrders }: TOrdersTable
                     rowRender={(rowData: unknown) => (
                         <OrdersTableRowRenderer {...(rowData as TOrdersTableRowRendererProps)} />
                     )}
+                    tableClassname=''
                 />
             )}
         </div>


### PR DESCRIPTION
- Updated useFetchMore function and wrapped loadMore with debounce so it doesn't spam the loadMore function, as there are brief moments it will call it multiple times once it reaches the bottom.
- Migrated all Table components from deriv-com/ui to V2 version of it as theres a lot of ui issues if we try to upgrade the package
- Removed margin top for Loader in buy/sell page
- Fixed height scrolling issues in Orders and MyCounterparties tables

### Before
![Screenshot 2024-08-07 at 10 29 32 AM](https://github.com/user-attachments/assets/fadd894e-69fb-425e-8c46-c9c9de4e3954)
![Screenshot 2024-08-07 at 10 29 47 AM](https://github.com/user-attachments/assets/ca6c616b-9f5b-4aa1-af50-9c003032d38c)
![Screenshot 2024-08-07 at 3 56 05 PM](https://github.com/user-attachments/assets/38ed114e-1ba3-45ad-b0ac-edc8968d74c4)


https://github.com/user-attachments/assets/afc6aad2-ef70-4b33-916c-8a5ada435c8c

### After
![Screenshot 2024-08-07 at 10 29 57 AM](https://github.com/user-attachments/assets/d983345e-3328-4b65-be87-b82f84942f5f)
![Screenshot 2024-08-07 at 10 30 02 AM](https://github.com/user-attachments/assets/0a4d5096-2110-4858-8ebd-0ec4d6d053ca)
![Screenshot 2024-08-07 at 3 56 54 PM](https://github.com/user-attachments/assets/fa41a072-5f6d-4d2a-bf3c-3d0e065e93b2)


https://github.com/user-attachments/assets/c3f293b3-78e7-4f4d-8803-17dff1038868


https://github.com/user-attachments/assets/b53ec38c-7caf-4cd3-a80c-b97022113cab




