### PR TITLE
Nada/fix: advertiser table multiple api calls issue

### DIFF
--- a/src/components/PopoverDropdown/PopoverDropdown.tsx
+++ b/src/components/PopoverDropdown/PopoverDropdown.tsx
@@ -1,6 +1,5 @@
 import { useRef, useState } from 'react';
 import { useOnClickOutside } from 'usehooks-ts';
-import { useIsAdvertiserBarred } from '@/hooks/custom-hooks';
 import { LabelPairedEllipsisVerticalLgBoldIcon } from '@deriv/quill-icons';
 import { Button, Text, useDevice } from '@deriv-com/ui';
 import { TooltipMenuIcon } from '../TooltipMenuIcon';
@@ -13,20 +12,20 @@ type TItem = {
 
 type TPopoverDropdownProps = {
     dropdownList: TItem[];
+    isBarred: boolean;
     onClick: (value: string) => void;
     tooltipMessage: string;
 };
 
-const PopoverDropdown = ({ dropdownList, onClick, tooltipMessage }: TPopoverDropdownProps) => {
+const PopoverDropdown = ({ dropdownList, isBarred, onClick, tooltipMessage }: TPopoverDropdownProps) => {
     const [visible, setVisible] = useState(false);
     const ref = useRef(null);
     useOnClickOutside(ref, () => setVisible(false));
     const { isDesktop } = useDevice();
-    const isAdvertiserBarred = useIsAdvertiserBarred();
 
     return (
         <div className='popover-dropdown' data-testid='dt_popover_dropdown' ref={ref}>
-            {isAdvertiserBarred ? (
+            {isBarred ? (
                 <LabelPairedEllipsisVerticalLgBoldIcon data-testid='dt_popover_dropdown_icon' fill='#999999' />
             ) : (
                 <TooltipMenuIcon
@@ -43,7 +42,7 @@ const PopoverDropdown = ({ dropdownList, onClick, tooltipMessage }: TPopoverDrop
                         <Button
                             className='popover-dropdown__list-item'
                             color='black'
-                            disabled={isAdvertiserBarred}
+                            disabled={isBarred}
                             key={item.value}
                             onClick={() => {
                                 onClick(item.value);

--- a/src/components/PopoverDropdown/__tests__/PopoverDropdown.spec.tsx
+++ b/src/components/PopoverDropdown/__tests__/PopoverDropdown.spec.tsx
@@ -1,4 +1,3 @@
-import { useIsAdvertiserBarred } from '@/hooks';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import PopoverDropdown from '../PopoverDropdown';
@@ -25,11 +24,10 @@ const mockProps = {
             value: 'value 2',
         },
     ],
+    isBarred: false,
     onClick: jest.fn(),
     tooltipMessage: 'test tooltip message',
 };
-
-const mockUseIsAdvertiserBarred = useIsAdvertiserBarred as jest.MockedFunction<typeof useIsAdvertiserBarred>;
 
 describe('PopoverDropdown', () => {
     it('should render', () => {
@@ -49,8 +47,7 @@ describe('PopoverDropdown', () => {
     });
 
     it('should disable the icon if advertiser is barred', async () => {
-        mockUseIsAdvertiserBarred.mockReturnValue(true);
-        render(<PopoverDropdown {...mockProps} />);
+        render(<PopoverDropdown {...mockProps} isBarred />);
         expect(screen.getByTestId('dt_popover_dropdown_icon')).not.toHaveProperty('onClick');
     });
 });

--- a/src/hooks/custom-hooks/useIsAdvertiserBarred.ts
+++ b/src/hooks/custom-hooks/useIsAdvertiserBarred.ts
@@ -12,14 +12,12 @@ const useIsAdvertiserBarred = (): boolean => {
     const invalidate = useInvalidateQuery();
 
     useEffect(() => {
-        invalidate('p2p_advertiser_adverts');
-        if (data.blocked_until) {
-            setIsAdvertiserBarred(true);
-        } else {
-            setIsAdvertiserBarred(false);
+        if (isAdvertiserBarred !== !!data.blocked_until) {
+            invalidate('p2p_advertiser_adverts');
+            setIsAdvertiserBarred(!!data.blocked_until);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [data.blocked_until]);
+    }, [isAdvertiserBarred, data.blocked_until]);
 
     return isAdvertiserBarred;
 };

--- a/src/pages/my-ads/screens/MyAds/MyAdsTableRow/MyAdsTableRow.tsx
+++ b/src/pages/my-ads/screens/MyAds/MyAdsTableRow/MyAdsTableRow.tsx
@@ -122,6 +122,7 @@ const MyAdsTableRow = ({ currentRateType, showModal, ...rest }: TMyAdsTableProps
                         {showAlertIcon && <AlertComponent onClick={() => showModal('AdErrorTooltipModal')} />}
                         <PopoverDropdown
                             dropdownList={getList(localize, isAdActive)}
+                            isBarred={isBarred}
                             onClick={handleClick}
                             tooltipMessage={localize('Manage ad')}
                         />
@@ -209,6 +210,7 @@ const MyAdsTableRow = ({ currentRateType, showModal, ...rest }: TMyAdsTableProps
                 <AdStatus isActive={isAdActive} />
                 <PopoverDropdown
                     dropdownList={getList(localize, isAdActive)}
+                    isBarred={isBarred}
                     onClick={handleClick}
                     tooltipMessage={localize('Manage ad')}
                 />


### PR DESCRIPTION
This pr fixes the issue where multiple api calls were placed for p2p_advertiser_adverts on page refresh

Before: 

https://github.com/user-attachments/assets/9ad7ef42-4b36-49f8-862d-a793ab87a3ae



After :

https://github.com/user-attachments/assets/7add7c19-38d7-4f47-826f-e95389859826
