### PR TITLE
Ameerul / FEQ-2587 Incorrect rate for floating rate order

### DIFF
--- a/src/components/BuySellForm/BuySellAmount/BuySellAmount.tsx
+++ b/src/components/BuySellForm/BuySellAmount/BuySellAmount.tsx
@@ -51,6 +51,7 @@ const BuySellAmount = ({
         setBuySellAmount(
             FormatUtils.formatMoney(Number(inputValue) * Number(calculatedRate), {
                 currency: localCurrency,
+                decimalPlaces: 2,
             })
         );
     }, [calculatedRate, inputValue, localCurrency, setBuySellAmount]);

--- a/src/hooks/custom-hooks/useExtendedOrderDetails.ts
+++ b/src/hooks/custom-hooks/useExtendedOrderDetails.ts
@@ -109,7 +109,7 @@ const useExtendedOrderDetails = ({
                     FormatUtils.formatMoney(
                         Number(this.amount_display) *
                             Number(roundOffDecimal(this.rate, setDecimalPlaces(this.rate, 6))),
-                        { currency: this.local_currency as TCurrency }
+                        { currency: this.local_currency as TCurrency, decimalPlaces: 2 }
                     )
                 );
             }


### PR DESCRIPTION
- passed decimal places prop as 2, for some reason, it doesn't do it by default when we format the money values to 2 by default, even though it mentions it would.
- Fixes issues in Buy/Sell modal, Order confirm modal, Order Info Header and Card info

## Before
![Screenshot 2024-08-12 at 5 19 18 PM](https://github.com/user-attachments/assets/21b48736-0b81-4124-af29-80fdd4ec5ed6)
![Screenshot 2024-08-12 at 5 31 25 PM](https://github.com/user-attachments/assets/955aa969-5f83-4bbb-a0bf-fde644f73d83)
![Screenshot 2024-08-12 at 5 30 42 PM](https://github.com/user-attachments/assets/e5364deb-c077-4d45-a511-849a632fae2e)


## After
![Screenshot 2024-08-12 at 5 19 25 PM](https://github.com/user-attachments/assets/0da0cd0c-96a6-4ed4-aca7-6a5de72df2c5)
![Screenshot 2024-08-12 at 5 35 50 PM](https://github.com/user-attachments/assets/1c66c196-052e-4b36-aec1-b4a785be82d7)
![Screenshot 2024-08-12 at 5 36 32 PM](https://github.com/user-attachments/assets/0f6fc758-dd0b-4378-a114-375fcd55ccf4)

