### PR TITLE
amam/disable cache for development and staging

### DIFF
--- a/src/hooks/custom-hooks/__tests__/useDerivAnalytics.spec.tsx
+++ b/src/hooks/custom-hooks/__tests__/useDerivAnalytics.spec.tsx
@@ -103,6 +103,9 @@ describe('useDerivAnalytics', () => {
         expect(Analytics.initialise).toHaveBeenCalledWith({
             growthbookDecryptionKey: process.env.VITE_GROWTHBOOK_DECRYPTION_KEY,
             growthbookKey: process.env.VITE_GROWTHBOOK_CLIENT_KEY,
+            growthbookOptions: {
+                disableCache: true,
+            },
             rudderstackKey: process.env.VITE_RUDDERSTACK_KEY || '',
         });
 

--- a/src/hooks/custom-hooks/useDerivAnalytics.ts
+++ b/src/hooks/custom-hooks/useDerivAnalytics.ts
@@ -20,6 +20,7 @@ const useDerivAnalytics = () => {
         try {
             const isDerivAnalyticsInitialized = Analytics?.getInstances()?.tracking?.has_initialized;
             const isLocalHost = location.hostname === 'localhost';
+            const isProduction = process.env.NODE_ENV === 'production';
 
             if (!isLocalHost && !isDerivAnalyticsInitialized) {
                 const remoteConfigURL = process.env.VITE_REMOTE_CONFIG_URL;
@@ -43,6 +44,9 @@ const useDerivAnalytics = () => {
                         ? process.env.VITE_GROWTHBOOK_DECRYPTION_KEY
                         : undefined,
                     growthbookKey: services?.marketing_growthbook ? process.env.VITE_GROWTHBOOK_CLIENT_KEY : undefined,
+                    growthbookOptions: {
+                        disableCache: !isProduction,
+                    },
                     rudderstackKey: services?.tracking_rudderstack ? process.env.VITE_RUDDERSTACK_KEY || '' : '',
                 });
 


### PR DESCRIPTION
**Motivation**
Cache were implemented in growthbook for cost saving measure and to make the response quick, however the cache is unneeded for low traffic in staging or dev, hence disabling it

**Changes**
- add disable cache logic during init