### PR TITLE
Ameerul / Fix language switcher not changing icon and code in Firefox

### DIFF
--- a/src/components/AppFooter/LanguageSettings.tsx
+++ b/src/components/AppFooter/LanguageSettings.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { LANGUAGES } from '@/constants';
 import { useTranslations } from '@deriv-com/translations';
 import { Text } from '@deriv-com/ui';
+import { LocalStorageUtils } from '@deriv-com/utils';
 import { TooltipMenuIcon } from '../TooltipMenuIcon';
 
 type TLanguageSettings = {
@@ -9,7 +10,8 @@ type TLanguageSettings = {
 };
 
 const LanguageSettings = ({ openLanguageSettingModal }: TLanguageSettings) => {
-    const { currentLang, localize } = useTranslations();
+    const { localize } = useTranslations();
+    const currentLang = LocalStorageUtils.getValue<string>('i18n_language') || 'EN';
 
     const countryIcon = useMemo(
         () => LANGUAGES.find(({ code }) => code == currentLang)?.placeholderIcon,


### PR DESCRIPTION
- The language icon and code wasn't switching in firefox after switching languages, but everything else was working properly. What we found was that the `currentLang` was returning 'EN' by default from the translations package, so instead we should grab it from local storage. 