### PR TITLE
Ameerul / FEQ-2611 [Firefox] On Past order page the Date filter tabs text seems to be overlapping

### DIFF
--- a/src/components/DateTextField/DateTextField.scss
+++ b/src/components/DateTextField/DateTextField.scss
@@ -20,6 +20,7 @@
             align-items: center;
 
             input {
+                outline: none;
                 @include desktop {
                     padding-left: 1rem;
                 }

--- a/src/pages/orders/components/OrdersDateSelection/OrdersDateSelection.scss
+++ b/src/pages/orders/components/OrdersDateSelection/OrdersDateSelection.scss
@@ -12,6 +12,7 @@
 
     &__input {
         input {
+            outline: none;
             padding-left: 1rem;
         }
     }


### PR DESCRIPTION
- Added opacity 0 to the input for past order date filters


https://github.com/user-attachments/assets/bb6a2340-8941-40ef-a9f7-edada8973abc

