### PR TITLE
Ako/ to check for website_status before initialising the analytics package

### DIFF
--- a/src/hooks/custom-hooks/useDerivAnalytics.ts
+++ b/src/hooks/custom-hooks/useDerivAnalytics.ts
@@ -22,7 +22,7 @@ const useDerivAnalytics = () => {
             const isLocalHost = location.hostname === 'localhost';
             const isProduction = process.env.NODE_ENV === 'production';
 
-            if (!isLocalHost && !isDerivAnalyticsInitialized) {
+            if (!isLocalHost && !isDerivAnalyticsInitialized && websiteStatus) {
                 const remoteConfigURL = process.env.VITE_REMOTE_CONFIG_URL;
                 let services = FIREBASE_INIT_DATA;
                 if (remoteConfigURL) {
@@ -51,7 +51,6 @@ const useDerivAnalytics = () => {
                 });
 
                 await Analytics?.getInstances()?.ab?.GrowthBook?.init();
-
                 Analytics.setAttributes({
                     account_type: activeAccount?.account_type || 'unlogged',
                     app_id: String(WebSocketUtils.getAppId()),


### PR DESCRIPTION

This is to make sure website status is available before initialising the analytics package.

This will make sure that the clients country is available.
