### PR TITLE
Ameerul / FEQ-2627 My Counterparties tab is not showing the correct message for temp banned user

### DIFF
--- a/src/components/Modals/BlockUnblockUserModal/__tests__/BlockUnblockUserModal.spec.tsx
+++ b/src/components/Modals/BlockUnblockUserModal/__tests__/BlockUnblockUserModal.spec.tsx
@@ -136,7 +136,7 @@ describe('BlockUnblockUserModal', () => {
         expect(mockOnRequestClose).toBeCalled();
     });
 
-    it('should call onClickBlocked and onRequestClose if isSuccess if mutation returns success', async () => {
+    it('should call onClickBlocked and onRequestClose if isSuccess or mutation returns success', async () => {
         mockBlockMutation.isSuccess = true;
         const mockOnClickBlocked = jest.fn();
         render(


### PR DESCRIPTION
- Added new store to help persist any error messages that need to be persisted.
- Added missing error message when trying to block a user when you are banned


https://github.com/user-attachments/assets/95d93113-a5de-421c-af35-b2e7e01222bb


https://github.com/user-attachments/assets/0506182a-de91-4239-98b7-411c4e4c2e1f


https://github.com/user-attachments/assets/6aa6805d-2bce-41ad-a8d0-aa6e4df6b97a

<img width="1694" alt="Screenshot 2024-09-06 at 4 15 00 PM" src="https://github.com/user-attachments/assets/d1c71f07-721e-4077-a2b1-7f2fef5e14a3">
<img width="631" alt="Screenshot 2024-09-06 at 5 25 51 PM" src="https://github.com/user-attachments/assets/21ec6206-3511-4805-8f2e-1eb8c59f3ebb">


