### PR TITLE
Ameerul / FEQ-2632 Endpoint page become blank when click on Reset button

### DIFF
--- a/src/pages/endpoint/screens/Endpoint/Endpoint.tsx
+++ b/src/pages/endpoint/screens/Endpoint/Endpoint.tsx
@@ -1,4 +1,5 @@
 import { Controller, useForm } from 'react-hook-form';
+import { getServerInfo } from '@/constants';
 import { Button, Input, Text } from '@deriv-com/ui';
 import { LocalStorageConstants, LocalStorageUtils } from '@deriv-com/utils';
 import './Endpoint.scss';
@@ -86,7 +87,7 @@ const Endpoint = () => {
                             LocalStorageUtils.setValue<string>(LocalStorageConstants.configServerURL, '');
                             LocalStorageUtils.setValue<string>(LocalStorageConstants.configAppId, '');
                             reset();
-                            window.location.reload();
+                            getServerInfo();
                         }}
                         variant='outlined'
                     >

--- a/src/pages/endpoint/screens/Endpoint/__tests__/Endpoint.spec.tsx
+++ b/src/pages/endpoint/screens/Endpoint/__tests__/Endpoint.spec.tsx
@@ -2,6 +2,12 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Endpoint from '../Endpoint';
 
+const mockGetServerInfo = jest.fn();
+
+jest.mock('@/constants', () => ({
+    getServerInfo: jest.fn(() => mockGetServerInfo()),
+}));
+
 describe('<Endpoint />', () => {
     it('should render the endpoint component', () => {
         render(<Endpoint />);
@@ -28,7 +34,7 @@ describe('<Endpoint />', () => {
         expect(JSON.parse(localStorage.getItem('config.app_id') || '')).toBe('123');
     });
 
-    it('should reset the server_url and app_id when user clicks on the reset button', async () => {
+    it('should call getServerInfo and reset the inputs when user clicks on the reset button', async () => {
         render(<Endpoint />);
 
         const serverUrlInput = screen.getByTestId('dt_endpoint_server_url_input');
@@ -41,5 +47,6 @@ describe('<Endpoint />', () => {
 
         expect(JSON.parse(localStorage.getItem('config.server_url') || '')).toBe('');
         expect(JSON.parse(localStorage.getItem('config.app_id') || '')).toBe('');
+        expect(mockGetServerInfo).toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
- Called getServerInfo function on reset as this is where it sets the production appid and server url in the localstorage
- updated endpoint test cases

Below is just a small example where I manually changed the app id and server url 

https://github.com/user-attachments/assets/4067aa7c-5bd5-4dca-90af-33e9ba5a4ec4


