### PR TITLE
Ameerul / FEQ-2661 Incorrect pop up displayed when advertiser tries to block another use

### DIFF
--- a/src/components/AdvertsTableRow/AdvertsTableRow.tsx
+++ b/src/components/AdvertsTableRow/AdvertsTableRow.tsx
@@ -78,6 +78,8 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
         else if (isTablet) return 'sm';
         return 'md';
     };
+    const params = new URLSearchParams(location.search);
+    const advertIdParam = params.get('advert_id');
 
     const redirectToAdvertiser = () => {
         isAdvertiserBarred ? undefined : history.push(`${ADVERTISER_URL}/${id}?currency=${localCurrency}`);
@@ -240,7 +242,7 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
                     )}
                 </Container>
             </Container>
-            {isModalOpenFor('BuySellForm') && (
+            {!advertIdParam && isModalOpenFor('BuySellForm') && (
                 <BuySellForm
                     advertId={advertId}
                     isModalOpen={!!isModalOpenFor('BuySellForm')}

--- a/src/components/BuySellForm/BuySellForm.tsx
+++ b/src/components/BuySellForm/BuySellForm.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import { Control, FieldValues, useForm } from 'react-hook-form';
 import { useHistory } from 'react-router-dom';
 import { TCurrency, THooks, TPaymentMethod } from 'types';
-import { ErrorModal, RateFluctuationModal } from '@/components/Modals';
+import { ErrorModal, LoadingModal, RateFluctuationModal } from '@/components/Modals';
 import { BUY_SELL, ERROR_CODES, ORDERS_URL, RATE_TYPE } from '@/constants';
 import { api } from '@/hooks';
 import useInvalidateQuery from '@/hooks/api/useInvalidateQuery';
@@ -50,7 +50,7 @@ const getAdvertiserMaxLimit = (
 const BuySellForm = ({ advertId, isModalOpen, onRequestClose }: TBuySellFormProps) => {
     const { localize } = useTranslations();
     const { hideModal, isModalOpenFor, showModal } = useModalManager();
-    const { data: advertInfo, subscribe, unsubscribe } = api.advert.useSubscribe();
+    const { data: advertInfo, isLoading, subscribe, unsubscribe } = api.advert.useSubscribe();
     const { data: orderCreatedInfo, error, isError, isSuccess, mutate, reset } = api.order.useCreate();
     const { data: paymentMethods } = api.paymentMethods.useGet();
     const { data: advertiserPaymentMethods, get } = api.advertiserPaymentMethods.useGet();
@@ -273,6 +273,8 @@ const BuySellForm = ({ advertId, isModalOpen, onRequestClose }: TBuySellFormProp
 
         setShowLowBalanceError(isLowBalance);
     }, [balanceData.balance, isBuy, minOrderAmountLimit]);
+
+    if (isLoading) return <LoadingModal isModalOpen />;
 
     return (
         <form onSubmit={handleSubmit(onSubmit)}>

--- a/src/components/BuySellForm/__tests__/BuySellForm.spec.tsx
+++ b/src/components/BuySellForm/__tests__/BuySellForm.spec.tsx
@@ -90,6 +90,7 @@ const mockModalManager = {
 
 const mockAdvertInfo = {
     data: mockAdvertValues,
+    isLoading: true,
     subscribe: jest.fn(),
     unsubscribe: jest.fn(),
 };
@@ -201,7 +202,12 @@ describe('BuySellForm', () => {
     afterEach(() => {
         jest.clearAllMocks();
     });
+    it('should render the loading modal when isLoading is true', () => {
+        render(<BuySellForm {...mockProps} />);
+        expect(screen.getByTestId('dt_derivs-loader')).toBeInTheDocument();
+    });
     it('should render the form as expected', () => {
+        mockAdvertInfo.isLoading = false;
         render(<BuySellForm {...mockProps} />);
         expect(screen.getByText('Buy USD')).toBeInTheDocument();
     });

--- a/src/components/Modals/ErrorModal/ErrorModal.scss
+++ b/src/components/Modals/ErrorModal/ErrorModal.scss
@@ -1,11 +1,5 @@
 .error-modal {
-    width: 44rem;
-    height: unset;
-    border-radius: 8px;
-
-    @include mobile-or-tablet-screen {
-        max-width: 34rem;
-    }
+    @include default-modal;
 
     &__body {
         padding: 2.4rem;

--- a/src/components/Modals/LoadingModal/LoadingModal.scss
+++ b/src/components/Modals/LoadingModal/LoadingModal.scss
@@ -2,12 +2,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 3rem 0;
-    width: 44rem;
     height: unset;
-    border-radius: 8px;
+    padding: 5rem 0;
 
-    @include mobile-or-tablet-screen {
-        max-width: 32rem;
-    }
+    @include default-modal;
 }

--- a/src/components/Modals/LoadingModal/LoadingModal.tsx
+++ b/src/components/Modals/LoadingModal/LoadingModal.tsx
@@ -5,7 +5,7 @@ const LoadingModal = ({ isModalOpen }: { isModalOpen: boolean }) => {
     return (
         <Modal ariaHideApp={false} className='loading-modal' isOpen={isModalOpen}>
             <Modal.Body>
-                <Loader className='relative top-0 left-0 transform-none' />
+                <Loader />
             </Modal.Body>
         </Modal>
     );

--- a/src/components/Modals/ShareAdsModal/ShareAdsModal.tsx
+++ b/src/components/Modals/ShareAdsModal/ShareAdsModal.tsx
@@ -35,7 +35,7 @@ const ShareAdsModal = ({ id, isModalOpen, onRequestClose }: TShareAdsModalProps)
     const { id: advertiserId } = advertiserDetails ?? {};
 
     const divRef = useRef<HTMLDivElement | null>(null);
-    const advertUrl = `${websiteUrl()}${ADVERTISER_URL}/${advertiserId}?advert_id=${id}&currency=${localCurrency}`;
+    const advertUrl = `${websiteUrl()}${ADVERTISER_URL}/${advertiserId}?advert_id=${id}`;
     const isBuyAd = type === BUY_SELL.BUY;
     const firstCurrency = isBuyAd ? localCurrency : accountCurrency;
     const secondCurrency = isBuyAd ? accountCurrency : localCurrency;

--- a/src/components/Modals/ShareAdsModal/__tests__/ShareAdsModal.spec.tsx
+++ b/src/components/Modals/ShareAdsModal/__tests__/ShareAdsModal.spec.tsx
@@ -88,7 +88,7 @@ describe('ShareAdsModal', () => {
         await userEvent.click(copyButton);
 
         expect(mockCopyFn).toHaveBeenCalledWith(
-            `${window.location.href}advertiser/${mockUseGet.data.advertiser_details.id}?advert_id=${mockProps.id}&currency=${mockUseGet.data.local_currency}`
+            `${window.location.href}advertiser/${mockUseGet.data.advertiser_details.id}?advert_id=${mockProps.id}`
         );
     });
     it('should call html2canvas function when clicking on Download this QR code button', async () => {

--- a/src/pages/advertiser/screens/Advertiser/Advertiser.scss
+++ b/src/pages/advertiser/screens/Advertiser/Advertiser.scss
@@ -11,9 +11,9 @@
         width: 100%;
     }
 
-    & .page-return {
+    &__return {
         @include mobile-or-tablet-screen {
-            padding: 0.5rem 1.6rem;
+            padding: 1rem 1.6rem;
         }
     }
 }

--- a/src/pages/advertiser/screens/Advertiser/Advertiser.tsx
+++ b/src/pages/advertiser/screens/Advertiser/Advertiser.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import clsx from 'clsx';
 import { useHistory, useLocation, useParams } from 'react-router-dom';
 import { PageReturn, ProfileContent } from '@/components';
 import BlockDropdown from '@/components/AdvertiserName/BlockDropdown';
@@ -29,10 +30,12 @@ const Advertiser = () => {
 
     const { data, isLoading, unsubscribe } = useAdvertiserStats(id);
 
+    const isDropdownVisible = !isSameUser && !isDesktop && !data?.isBlockedBoolean;
+
     return (
         <div className='advertiser'>
             <PageReturn
-                className='lg:mt-0'
+                className={clsx('lg:mt-0', { advertiser__return: isDropdownVisible })}
                 hasBorder={!isDesktop}
                 onClick={() => {
                     history.push(
@@ -43,17 +46,16 @@ const Advertiser = () => {
                     unsubscribe();
                 }}
                 pageTitle={localize('Advertiser’s page')}
-                {...(!isDesktop &&
-                    !isSameUser && {
-                        rightPlaceHolder: (
-                            <BlockDropdown
-                                id={advertiserId}
-                                onClickBlocked={() => {
-                                    setShowOverlay(prevState => !prevState);
-                                }}
-                            />
-                        ),
-                    })}
+                {...(isDropdownVisible && {
+                    rightPlaceHolder: (
+                        <BlockDropdown
+                            id={advertiserId}
+                            onClickBlocked={() => {
+                                setShowOverlay(prevState => !prevState);
+                            }}
+                        />
+                    ),
+                })}
                 size={isMobile ? 'lg' : 'md'}
                 weight='bold'
             />

--- a/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.scss
+++ b/src/pages/advertiser/screens/AdvertiserAdvertsTable/AdvertiserAdvertsTable.scss
@@ -24,8 +24,8 @@
     }
 
     & .mobile-wrapper {
-        @include mobile {
-            height: calc(100% - 3.5rem);
+        @include mobile-or-tablet-screen {
+            height: 100%;
         }
     }
 }

--- a/src/pages/advertiser/screens/AdvertiserAdvertsTable/__tests__/AdvertiserAdvertsTable.spec.tsx
+++ b/src/pages/advertiser/screens/AdvertiserAdvertsTable/__tests__/AdvertiserAdvertsTable.spec.tsx
@@ -119,14 +119,6 @@ const mockUseGet = api.advert.useGet as jest.MockedFunction<typeof api.advert.us
 const mockUseIsAdvertiserBarred = useIsAdvertiserBarred as jest.MockedFunction<typeof useIsAdvertiserBarred>;
 
 describe('<AdvertiserAdvertsTable />', () => {
-    it('should show the Loader component if isLoading is true', () => {
-        render(<AdvertiserAdvertsTable advertiserId='123' />);
-
-        expect(screen.getByRole('button', { name: 'Buy' })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: 'Sell' })).toBeInTheDocument();
-        expect(screen.getByTestId('dt_derivs-loader')).toBeInTheDocument();
-    });
-
     it('should call setQueryString if queryString is not defined', async () => {
         render(<AdvertiserAdvertsTable advertiserId='123' />);
 
@@ -212,20 +204,6 @@ describe('<AdvertiserAdvertsTable />', () => {
 
         expect(screen.getByRole('button', { name: 'Sell USD' })).toBeInTheDocument();
         expect(mockTabsStore.setActiveAdvertisersBuySellTab).toHaveBeenCalledWith('Sell');
-    });
-
-    it('should show LoadingModal if isLoading is true and advertId is present', () => {
-        (mockUseGet as jest.Mock).mockReturnValue({
-            ...mockUseGetAdvertInfo,
-            data: undefined,
-            isLoading: true,
-        });
-        mockSearch = '?advert_id=456';
-        mockUseModalManager.isModalOpenFor.mockImplementation((modal: string) => modal === 'LoadingModal');
-
-        render(<AdvertiserAdvertsTable advertiserId='222' />);
-
-        expect(screen.getByTestId('dt_derivs-loader')).toBeInTheDocument();
     });
 
     it('should show BuySellForm if user is an advertiser, not barred, isLoading is false, advertId is present, advert is active and visible', () => {

--- a/src/routes/Router.tsx
+++ b/src/routes/Router.tsx
@@ -13,7 +13,7 @@ declare module 'react-router-dom' {
     export function useHistory(): {
         goBack: () => void;
         push: (path: string, state?: TState) => void;
-        replace(arg0: { pathname: string; search: string }): void;
+        replace(arg0: { pathname?: string; search: string }): void;
     };
 
     export function useRouteMatch(path: string): boolean;


### PR DESCRIPTION
- Clear the search params after user closes the buy sell modal after opening a shared advert
- Remove currency from the p2p_advert_info call as BE included a change where we don't need to pass it anymore, just the id.
- Removed showing LoadingModal in Advertiser page, let it be handled internally in the BuySellForm, this will fix issues related to Buy showing by default before showing a Sell advert
- Hid the dropdown in responsive when the user is blocked

### Block Dropdown
![Screenshot 2024-09-19 at 1 47 05 PM](https://github.com/user-attachments/assets/541e2c31-8e57-4f0e-943d-8a5a03c28de8)
![Screenshot 2024-09-19 at 1 47 14 PM](https://github.com/user-attachments/assets/0346e6a5-09a6-421b-ad8d-6a2d760d7e00)

### Error Modal Width
![Screenshot 2024-09-19 at 1 47 36 PM](https://github.com/user-attachments/assets/ebbbed04-1753-4f2a-bfc1-092bd1740ddd)
![Screenshot 2024-09-19 at 1 47 49 PM](https://github.com/user-attachments/assets/42755b92-6695-4a46-b93d-38549f42918f)


https://github.com/user-attachments/assets/bfc48fa5-658b-400c-9e01-5066be94a67d

