### PR TITLE
Remove verify user step

### DIFF
--- a/.github/workflows/smoketests.yml
+++ b/.github/workflows/smoketests.yml
@@ -19,12 +19,6 @@ jobs:
   trigger-workflow:
     runs-on: ubuntu-latest
     steps:
-    - name: Verify user
-      uses: 'deriv-com/shared-actions/.github/actions/verify_user_in_organization@v1'
-      with:
-          username: ${{ github.event.pull_request.user.login }}
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-
     - name: Download artifact
       id: download-artifact
       uses: actions/download-artifact@v4


### PR DESCRIPTION
As suggested by Bala as it's not necessary now that we're only triggering from the deploy script.