### PR TITLE
Ameerul / FEQ-2666 "No" is selected by default in rating and recommendation modal

### DIFF
--- a/src/hooks/api/order/p2p-order/useOrderInfo.ts
+++ b/src/hooks/api/order/p2p-order/useOrderInfo.ts
@@ -35,7 +35,7 @@ const useOrderInfo = () => {
                 /** Indicates if the advertiser is currently online. */
                 is_online: Boolean(advertiser_details.is_online),
                 /** Indicates that the advertiser was recommended in the most recent review by the current user. */
-                is_recommended: Boolean(client_details.is_recommended),
+                is_recommended: Boolean(advertiser_details.is_recommended),
             },
             client_details: {
                 ...client_details,

--- a/src/hooks/custom-hooks/__tests__/useExtendedOrderDetails.spec.ts
+++ b/src/hooks/custom-hooks/__tests__/useExtendedOrderDetails.spec.ts
@@ -13,9 +13,17 @@ const mockData: {
         account_currency: 'USD',
         // @ts-expect-error - Only relevant fields are included
         advertiser_details: {
+            has_not_been_recommended: true,
+            is_recommended: false,
             loginid: '',
         },
         amount_display: '100',
+        // @ts-expect-error - Only relevant fields are included
+        client_details: {
+            has_not_been_recommended: false,
+            is_recommended: true,
+            loginid: '',
+        },
         type: 'buy',
     },
     serverTime: undefined,
@@ -378,6 +386,38 @@ describe('useExtendedOrderDetails', () => {
             const { result } = renderHook(() => useExtendedOrderDetails(mockData));
 
             expect(result.current.data.isSellOrder).toBe(true);
+        });
+    });
+
+    describe('isUserRecommended', () => {
+        it('should return client_details.is_recommended if isMyAd is true', () => {
+            mockData.orderDetails.advertiser_details.loginid = '123';
+            const { result } = renderHook(() => useExtendedOrderDetails(mockData));
+
+            expect(result.current.data.isUserRecommended).toBe(true);
+        });
+
+        it('should return advertiser_details.is_recommended if isMyAd is false', () => {
+            mockData.orderDetails.advertiser_details.loginid = '456';
+            const { result } = renderHook(() => useExtendedOrderDetails(mockData));
+
+            expect(result.current.data.isUserRecommended).toBe(false);
+        });
+    });
+
+    describe('isUserRecommendedPreviously', () => {
+        it('should return client_details.has_not_been_recommended if isMyAd is true', () => {
+            mockData.orderDetails.advertiser_details.loginid = '123';
+            const { result } = renderHook(() => useExtendedOrderDetails(mockData));
+
+            expect(result.current.data.isUserRecommendedPreviously).toBe(true);
+        });
+
+        it('should return advertiser_details.has_not_been_recommended if isMyAd is false', () => {
+            mockData.orderDetails.advertiser_details.loginid = '456';
+            const { result } = renderHook(() => useExtendedOrderDetails(mockData));
+
+            expect(result.current.data.isUserRecommendedPreviously).toBe(false);
         });
     });
 

--- a/src/hooks/custom-hooks/useExtendedOrderDetails.ts
+++ b/src/hooks/custom-hooks/useExtendedOrderDetails.ts
@@ -41,6 +41,8 @@ export interface ExtendedOrderDetails extends TOrder {
     isPendingOrder: boolean;
     isRefundedOrder: boolean;
     isSellOrder: boolean;
+    isUserRecommended: boolean;
+    isUserRecommendedPreviously: boolean;
     labels: TObject;
     myAdStatusString: TObject;
     orderExpiryMilliseconds: number;
@@ -183,6 +185,14 @@ const useExtendedOrderDetails = ({
 
         get isSellOrder() {
             return this.type === BUY_SELL.SELL;
+        },
+        get isUserRecommended() {
+            if (this.isMyAd) return this.client_details.is_recommended;
+            return this.advertiser_details.is_recommended;
+        },
+        get isUserRecommendedPreviously() {
+            if (this.isMyAd) return !this.client_details.has_not_been_recommended;
+            return !this.advertiser_details.has_not_been_recommended;
         },
         get labels() {
             if (this.isMyAd) {

--- a/src/pages/orders/components/OrderDetailsCard/OrderDetailsCardReview/OrderDetailsCardReview.tsx
+++ b/src/pages/orders/components/OrderDetailsCard/OrderDetailsCardReview/OrderDetailsCardReview.tsx
@@ -18,13 +18,14 @@ type TOrderDetailsCardReviewProps = {
 const OrderDetailsCardReview = ({ setShowRatingModal, showRatingModal }: TOrderDetailsCardReviewProps) => {
     const { orderDetails } = useOrderDetails();
     const {
-        client_details: clientDetails,
         completion_time: completionTime,
         hasReviewDetails,
         id,
         is_reviewable: isReviewable,
         isBuyOrderForUser,
         isCompletedOrder,
+        isUserRecommended,
+        isUserRecommendedPreviously,
         review_details: reviewDetails,
     } = orderDetails;
     const { data: p2pSettingsData } = api.settings.useSettings();
@@ -76,8 +77,8 @@ const OrderDetailsCardReview = ({ setShowRatingModal, showRatingModal }: TOrderD
                     <RatingModal
                         isBuyOrder={isBuyOrderForUser}
                         isModalOpen
-                        isRecommended={clientDetails?.is_recommended}
-                        isRecommendedPreviously={!clientDetails?.has_not_been_recommended}
+                        isRecommended={isUserRecommended}
+                        isRecommendedPreviously={isUserRecommendedPreviously}
                         onRequestClose={() => {
                             if (showRatingModal) setShowRatingModal(false);
                             hideModal();

--- a/src/pages/orders/screens/Orders/OrdersTableRow/OrdersTableRow.tsx
+++ b/src/pages/orders/screens/Orders/OrdersTableRow/OrdersTableRow.tsx
@@ -35,10 +35,11 @@ const OrdersTableRow = ({ ...props }: DeepPartial<THooks.Order.GetList[number]>)
     const {
         account_currency: accountCurrency,
         amount_display: amountDisplay,
-        client_details: clientDetails,
         id,
         isCompletedOrder,
         isOrderReviewable,
+        isUserRecommended,
+        isUserRecommendedPreviously,
         local_currency: localCurrency,
         price_display: priceDisplay,
         purchaseTime,
@@ -114,8 +115,8 @@ const OrdersTableRow = ({ ...props }: DeepPartial<THooks.Order.GetList[number]>)
                     <RatingModal
                         isBuyOrder={isBuyOrderForUser}
                         isModalOpen
-                        isRecommended={clientDetails.is_recommended}
-                        isRecommendedPreviously={!clientDetails.has_not_been_recommended}
+                        isRecommended={isUserRecommended}
+                        isRecommendedPreviously={isUserRecommendedPreviously}
                         onRequestClose={hideModal}
                         orderId={id}
                     />
@@ -158,8 +159,8 @@ const OrdersTableRow = ({ ...props }: DeepPartial<THooks.Order.GetList[number]>)
                 <RatingModal
                     isBuyOrder={isBuyOrderForUser}
                     isModalOpen
-                    isRecommended={clientDetails.is_recommended}
-                    isRecommendedPreviously={!clientDetails.has_not_been_recommended}
+                    isRecommended={isUserRecommended}
+                    isRecommendedPreviously={isUserRecommendedPreviously}
                     onRequestClose={hideModal}
                     orderId={id}
                 />


### PR DESCRIPTION
- Added new get values in useExtendedOrderDetails to return the correct value for if the user was rated previously and is recommended based on if it is their advert.
- added test cases

<img width="671" alt="Screenshot 2024-09-24 at 11 40 45 AM" src="https://github.com/user-attachments/assets/aa12a455-adf8-4d3e-9105-13af9849ead7">

https://github.com/user-attachments/assets/c9f0f293-b64f-4dab-988a-b12170f51606

