### PR TITLE
chore: use oauth library

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -16,5 +16,7 @@ module.exports = {
         '^.+\\.(js|jsx)$': 'babel-jest',
         '^.+\\.tsx?$': 'ts-jest',
     },
-    transformIgnorePatterns: ['/node_modules/(?!(@deriv-com/translations|@deriv-com/ui|@sendbird/chat)).+\\.js$'],
+    transformIgnorePatterns: [
+        '/node_modules/(?!(@deriv-com/translations|@deriv-com/ui|@sendbird/chat|@deriv-com/auth-client)).+\\.js$',
+    ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
                 "@chakra-ui/react": "^2.8.2",
                 "@deriv-com/analytics": "^1.16.1",
                 "@deriv-com/api-hooks": "^1.4.9",
+                "@deriv-com/auth-client": "1.0.15",
                 "@deriv-com/translations": "^1.3.7",
                 "@deriv-com/ui": "^1.35.5",
                 "@deriv-com/utils": "^0.0.28",
@@ -3828,6 +3829,21 @@
             "os": [
                 "linux"
             ]
+        },
+        "node_modules/@deriv-com/auth-client": {
+            "version": "1.0.15",
+            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.15.tgz",
+            "integrity": "sha512-2G6IUtPIX2TmlpW2khDUeltqfsxJtxZgiFdoHidW19rjZYDaj4aHDEh/RXArbiUUKF0i0FGgupzAuW4Id/o7SA==",
+            "dependencies": {
+                "@deriv-com/utils": "^0.0.33",
+                "react": "^18.3.1",
+                "react-dom": "^18.3.1"
+            }
+        },
+        "node_modules/@deriv-com/auth-client/node_modules/@deriv-com/utils": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.33.tgz",
+            "integrity": "sha512-LzIpzMvfWhK9y06Qpe/HOB4pFCizk2wAyhv9I0s48Romq+d5MM1mmsuh5CvS4SnzzdLyuBy4rgXrOO3394HB7w=="
         },
         "node_modules/@deriv-com/eslint-config-deriv": {
             "version": "2.1.0-beta.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@chakra-ui/react": "^2.8.2",
                 "@deriv-com/analytics": "^1.16.1",
                 "@deriv-com/api-hooks": "^1.4.9",
-                "@deriv-com/auth-client": "1.0.20",
+                "@deriv-com/auth-client": "1.0.23",
                 "@deriv-com/translations": "^1.3.7",
                 "@deriv-com/ui": "^1.35.5",
                 "@deriv-com/utils": "^0.0.28",
@@ -3831,13 +3831,11 @@
             ]
         },
         "node_modules/@deriv-com/auth-client": {
-            "version": "1.0.20",
-            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.20.tgz",
-            "integrity": "sha512-QZtS7UOwyH829rw1Wsx77jWRG4QH1d4yCj9w+1RwNJ7ZK+HNEWocqDL02Emo5WzdaDoIctwDjV+iHZRo9GftJQ==",
+            "version": "1.0.23",
+            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.23.tgz",
+            "integrity": "sha512-SeXDBwIuvFNqw21LS/VRTx7f4zPEBgPW3cM0kqcwAkjP4/Saihmo9j+RQHu9myGQZnWdqTtAMj8FZQC6P42+IA==",
             "dependencies": {
-                "@deriv-com/utils": "^0.0.33",
-                "react": "^18.3.1",
-                "react-dom": "^18.3.1"
+                "@deriv-com/utils": "^0.0.33"
             }
         },
         "node_modules/@deriv-com/auth-client/node_modules/@deriv-com/utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@chakra-ui/react": "^2.8.2",
                 "@deriv-com/analytics": "^1.16.1",
                 "@deriv-com/api-hooks": "^1.4.9",
-                "@deriv-com/auth-client": "1.0.15",
+                "@deriv-com/auth-client": "1.0.20",
                 "@deriv-com/translations": "^1.3.7",
                 "@deriv-com/ui": "^1.35.5",
                 "@deriv-com/utils": "^0.0.28",
@@ -3831,9 +3831,9 @@
             ]
         },
         "node_modules/@deriv-com/auth-client": {
-            "version": "1.0.15",
-            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.15.tgz",
-            "integrity": "sha512-2G6IUtPIX2TmlpW2khDUeltqfsxJtxZgiFdoHidW19rjZYDaj4aHDEh/RXArbiUUKF0i0FGgupzAuW4Id/o7SA==",
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.20.tgz",
+            "integrity": "sha512-QZtS7UOwyH829rw1Wsx77jWRG4QH1d4yCj9w+1RwNJ7ZK+HNEWocqDL02Emo5WzdaDoIctwDjV+iHZRo9GftJQ==",
             "dependencies": {
                 "@deriv-com/utils": "^0.0.33",
                 "react": "^18.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@chakra-ui/react": "^2.8.2",
                 "@deriv-com/analytics": "^1.16.1",
                 "@deriv-com/api-hooks": "^1.4.9",
-                "@deriv-com/auth-client": "1.0.23",
+                "@deriv-com/auth-client": "1.0.27",
                 "@deriv-com/translations": "^1.3.7",
                 "@deriv-com/ui": "^1.35.5",
                 "@deriv-com/utils": "^0.0.28",
@@ -3831,9 +3831,9 @@
             ]
         },
         "node_modules/@deriv-com/auth-client": {
-            "version": "1.0.23",
-            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.23.tgz",
-            "integrity": "sha512-SeXDBwIuvFNqw21LS/VRTx7f4zPEBgPW3cM0kqcwAkjP4/Saihmo9j+RQHu9myGQZnWdqTtAMj8FZQC6P42+IA==",
+            "version": "1.0.27",
+            "resolved": "https://registry.npmjs.org/@deriv-com/auth-client/-/auth-client-1.0.27.tgz",
+            "integrity": "sha512-8nZVJeljFnu/zAKiXvye5P9yK5CFHwcs2gWi7YGmHx7nVBL1BnaxMNbc/2JuQAD/oKpHh81hNOLADBslyJBIeA==",
             "dependencies": {
                 "@deriv-com/utils": "^0.0.33"
             }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "dependencies": {
         "@babel/preset-env": "^7.24.5",
         "@chakra-ui/react": "^2.8.2",
+        "@deriv-com/auth-client": "1.0.15",
         "@deriv-com/analytics": "^1.16.1",
         "@deriv-com/api-hooks": "^1.4.9",
         "@deriv-com/translations": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@babel/preset-env": "^7.24.5",
         "@chakra-ui/react": "^2.8.2",
-        "@deriv-com/auth-client": "1.0.15",
+        "@deriv-com/auth-client": "1.0.20",
         "@deriv-com/analytics": "^1.16.1",
         "@deriv-com/api-hooks": "^1.4.9",
         "@deriv-com/translations": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@babel/preset-env": "^7.24.5",
         "@chakra-ui/react": "^2.8.2",
-        "@deriv-com/auth-client": "1.0.23",
+        "@deriv-com/auth-client": "1.0.27",
         "@deriv-com/analytics": "^1.16.1",
         "@deriv-com/api-hooks": "^1.4.9",
         "@deriv-com/translations": "^1.3.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dependencies": {
         "@babel/preset-env": "^7.24.5",
         "@chakra-ui/react": "^2.8.2",
-        "@deriv-com/auth-client": "1.0.20",
+        "@deriv-com/auth-client": "1.0.23",
         "@deriv-com/analytics": "^1.16.1",
         "@deriv-com/api-hooks": "^1.4.9",
         "@deriv-com/translations": "^1.3.7",

--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -1,13 +1,9 @@
-import { useCallback, useEffect } from 'react';
-import { getOAuthLogoutUrl, getOAuthOrigin, getOauthUrl } from '@/constants';
+import { useCallback } from 'react';
+import { getOauthUrl } from '@/constants';
 import { getCurrentRoute } from '@/utils';
 import { useAuthData } from '@deriv-com/api-hooks';
-import useOAuth2Enabled from './useOAuth2Enabled';
-
-type MessageEvent = {
-    data: 'logout_complete' | 'logout_error';
-    origin: string;
-};
+import { TOAuth2EnabledAppList, useOAuth2 } from '@deriv-com/auth-client';
+import useGrowthbookGetFeatureValue from './useGrowthbookGetFeatureValue';
 
 type UseOAuthReturn = {
     oAuthLogout: () => void;
@@ -16,11 +12,18 @@ type UseOAuthReturn = {
 
 /**
  * useOAuth - hooks to help with OAuth function such as logout and check auth state during render
- *
  * @returns {UseOAuthReturn}
  */
 const useOAuth = (): UseOAuthReturn => {
-    const [isOAuth2Enabled] = useOAuth2Enabled();
+    const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<TOAuth2EnabledAppList>({
+        featureFlag: 'hydra_be',
+    });
+
+    const oAuthGrowthbookConfig = {
+        OAuth2EnabledApps,
+        OAuth2EnabledAppsInitialised,
+    };
+
     const { logout } = useAuthData();
     const { error, isAuthorized, isAuthorizing } = useAuthData();
     const isEndpointPage = getCurrentRoute() === 'endpoint';
@@ -30,59 +33,7 @@ const useOAuth = (): UseOAuthReturn => {
         await logout();
         window.open(oauthUrl, '_self');
     };
-
-    useEffect(() => {
-        const onMessage = async (event: MessageEvent) => {
-            const allowedOrigin = getOAuthOrigin();
-            if (allowedOrigin === event.origin) {
-                if (event.data === 'logout_complete') {
-                    WSLogoutAndRedirect();
-                } else {
-                    // eslint-disable-next-line no-console
-                    console.warn('Unexpected message received: ', event.data);
-                }
-            } else {
-                // eslint-disable-next-line no-console
-                console.warn('Unexpected postmessage origin: ', event.origin);
-            }
-        };
-
-        window.addEventListener('message', onMessage);
-
-        return () => {
-            window.removeEventListener('message', onMessage);
-        };
-    }, []);
-
-    const OAuth2Logout = async () => {
-        let iframe: HTMLIFrameElement | null = document.getElementById('logout-iframe') as HTMLIFrameElement;
-        if (!iframe) {
-            iframe = document.createElement('iframe');
-            iframe.id = 'logout-iframe';
-            iframe.style.display = 'none';
-            document.body.appendChild(iframe);
-
-            // backend response message timeout, setting this as 10 seconds
-            setTimeout(() => {
-                WSLogoutAndRedirect();
-            }, 10000);
-        }
-
-        iframe.src = getOAuthLogoutUrl();
-
-        iframe.onerror = error => {
-            // eslint-disable-next-line no-console
-            console.error('There has been a problem with the logout: ', error);
-        };
-    };
-
-    const oAuthLogout = useCallback(async () => {
-        if (isOAuth2Enabled) {
-            OAuth2Logout();
-        } else {
-            WSLogoutAndRedirect();
-        }
-    }, [isOAuth2Enabled]);
+    const { OAuth2Logout: oAuthLogout } = useOAuth2(oAuthGrowthbookConfig, WSLogoutAndRedirect);
 
     const onRenderAuthCheck = useCallback(() => {
         if (


### PR DESCRIPTION
Motivation 
- Currently the OAuth2 implementation is in the consumer app. 

Actions 
- Install and use [auth-client library](https://github.com/deriv-com/auth-client)
- Update the logout function to one
- Remove the isOAuth2Enabled check
- Remove the iframe and onMessage logic