### PR TITLE
Ameerul / FEQ-2676 The loader icon is shifted towards the left corner of the screen when loading p2p.deriv.com

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,7 +43,13 @@ const App = () => {
             <ErrorBoundary fallback={<div>fallback component</div>}>
                 <QueryParamProvider adapter={ReactRouter5Adapter}>
                     <TranslationProvider defaultLang='EN' i18nInstance={i18nInstance}>
-                        <Suspense fallback={<Loader isFullScreen />}>
+                        <Suspense
+                            fallback={
+                                <div className='flex h-full w-full items-center justify-center'>
+                                    <Loader isFullScreen />
+                                </div>
+                            }
+                        >
                             {!isOAuth2Enabled && <DerivIframe />}
                             <AppHeader />
                             <AppContent />


### PR DESCRIPTION
- Wrapped Suspense Loader component in a div to position it in the centre. 

https://github.com/user-attachments/assets/80878213-4370-4716-8749-7cbeea7aecad

