### PR TITLE
Ameerul / WEBREL-3193 Payment Method disappears when create order page is idle

### DIFF
--- a/src/components/BuySellForm/BuySellForm.tsx
+++ b/src/components/BuySellForm/BuySellForm.tsx
@@ -103,11 +103,11 @@ const BuySellForm = ({ advertId, isModalOpen, onRequestClose }: TBuySellFormProp
     const counterpartyRateRef = useRef<number | undefined>(undefined);
 
     useEffect(() => {
-        if (isAdvertiser) {
+        if (isAdvertiser || advertiserPaymentMethods === undefined) {
             get();
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isAdvertiser]);
+    }, [isAdvertiser, advertiserPaymentMethods]);
 
     const { displayEffectiveRate, effectiveRate } = generateEffectiveRate({
         exchangeRate,


### PR DESCRIPTION
- Added advertiserPaymentMethods to the dependency array as it can go undefined after going idle, so this should refetch the data if this happens

