### PR TITLE
Ameerul / FEQ-2682 On Switching the language from english , the badges are not visible on My profile page

### DIFF
--- a/src/components/AdvertiserName/AdvertiserNameBadges.tsx
+++ b/src/components/AdvertiserName/AdvertiserNameBadges.tsx
@@ -17,7 +17,7 @@ const AdvertiserNameBadges = ({ advertiserStats }: { advertiserStats: DeepPartia
 
     return (
         <div className='advertiser-name-badges' data-testid='dt_advertiser_name_badges'>
-            {(totalOrders || 0) >= 100 && <Badge label='100+' status={localize('trades')} variant='warning' />}
+            {(totalOrders || 0) >= 100 && <Badge tradeCount={totalOrders} />}
             <Badge
                 label={localize('ID')}
                 status={getStatus(isIdentityVerified)}

--- a/src/components/AdvertiserName/AdvertiserNameBadges.tsx
+++ b/src/components/AdvertiserName/AdvertiserNameBadges.tsx
@@ -17,7 +17,7 @@ const AdvertiserNameBadges = ({ advertiserStats }: { advertiserStats: DeepPartia
 
     return (
         <div className='advertiser-name-badges' data-testid='dt_advertiser_name_badges'>
-            {(totalOrders || 0) >= 100 && <Badge tradeCount={totalOrders} />}
+            {(totalOrders || 0) >= 100 && <Badge status={localize('trades')} tradeCount={totalOrders} />}
             <Badge
                 label={localize('ID')}
                 status={getStatus(isIdentityVerified)}

--- a/src/components/AdvertiserName/AdvertiserNameBadges.tsx
+++ b/src/components/AdvertiserName/AdvertiserNameBadges.tsx
@@ -13,7 +13,7 @@ const AdvertiserNameBadges = ({ advertiserStats }: { advertiserStats: DeepPartia
     const { isAddressVerified, isIdentityVerified, totalOrders } = advertiserStats || {};
     const { localize } = useTranslations();
     const getStatus = (isVerified?: boolean) => (isVerified ? localize('verified') : localize('not verified'));
-    const getVariant = (isVerified?: boolean) => (isVerified ? localize('success') : localize('general'));
+    const getVariant = (isVerified?: boolean) => (isVerified ? 'success' : 'general');
 
     return (
         <div className='advertiser-name-badges' data-testid='dt_advertiser_name_badges'>

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -24,6 +24,11 @@ const Badge = ({ label, status, tradeCount, variant }: TBadgeProps) => {
                 <Text className='badge__label' color='white' weight='bold'>
                     {`${tradeCount >= 250 ? '250+' : '100+'}`}
                 </Text>
+                {status && (
+                    <Text className='badge__status' color='white'>
+                        {status}
+                    </Text>
+                )}
             </div>
         );
     }

--- a/src/pages/advertiser/screens/Advertiser/Advertiser.scss
+++ b/src/pages/advertiser/screens/Advertiser/Advertiser.scss
@@ -1,11 +1,10 @@
 .advertiser {
     position: absolute;
-    top: 1rem;
+    top: 0;
     background-color: #fff;
     width: 95.2rem;
 
     @include mobile-or-tablet-screen {
-        top: 0;
         overflow: auto;
         height: calc(100% - 7.4rem);
         width: 100%;


### PR DESCRIPTION
- Removed localize that was wrapping the variant strings in AdvertiserNameBadges
- Removed top 1rem for Advertiser page cause in some languages, it was appearing behind it like thai

### Advertiser Page 1rem issue
![Screenshot 2024-10-01 at 9 36 22 AM](https://github.com/user-attachments/assets/ed88c4b4-7ee0-4295-872a-8c9b854a38ce)



https://github.com/user-attachments/assets/cfff92f9-c387-41d6-8caa-f818237171b5



