### PR TITLE
chore: remove logout check

### DIFF
--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -36,13 +36,13 @@ const useOAuth = (): UseOAuthReturn => {
     const { OAuth2Logout: oAuthLogout } = useOAuth2(oAuthGrowthbookConfig, WSLogoutAndRedirect);
 
     const onRenderAuthCheck = useCallback(() => {
-        if (
-            (!isEndpointPage && !isAuthorized && !isAuthorizing) ||
-            (!isEndpointPage && error?.code === 'InvalidToken')
-        ) {
+        if (!isEndpointPage && error?.code === 'InvalidToken') {
             oAuthLogout();
         }
-    }, [isEndpointPage, isAuthorized, isAuthorizing, error, oAuthLogout]);
+        if (!isEndpointPage && !isAuthorized && !isAuthorizing) {
+            window.open(oauthUrl, '_self');
+        }
+    }, [isEndpointPage, error?.code, isAuthorized, isAuthorizing, oAuthLogout, oauthUrl]);
 
     return { oAuthLogout, onRenderAuthCheck };
 };

--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -36,11 +36,12 @@ const useOAuth = (): UseOAuthReturn => {
     const { OAuth2Logout: oAuthLogout } = useOAuth2(oAuthGrowthbookConfig, WSLogoutAndRedirect);
 
     const onRenderAuthCheck = useCallback(() => {
-        if (!isEndpointPage && error?.code === 'InvalidToken') {
-            oAuthLogout();
-        }
-        if (!isEndpointPage && !isAuthorized && !isAuthorizing) {
-            window.open(oauthUrl, '_self');
+        if (!isEndpointPage) {
+            if (error?.code === 'InvalidToken') {
+                oAuthLogout();
+            } else if (!isAuthorized && !isAuthorizing) {
+                window.open(oauthUrl, '_self');
+            }
         }
     }, [isEndpointPage, error?.code, isAuthorized, isAuthorizing, oAuthLogout, oauthUrl]);
 


### PR DESCRIPTION
Calling logout function onRender whenever its not authorized or authorizing, this is causing the SSO to not work cause its logging out the session before it hits the OAuth page and therefore the session is killed.
Changed the logic abit so we dont call logout but we go to the OAuth page and it will redirect us back correctly