### PR TITLE
CSIT-1563/Prince/ initial implementation of freshchat

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,6 +1,10 @@
 declare global {
     interface Window {
+        Analytics: unknown;
         DD_RUM: object | undefined;
+        FreshChat: {
+            initialize: (config: FreshChatConfig) => void;
+        };
         LC_API: {
             on_chat_ended: VoidFunction;
             open_chat_window: VoidFunction;
@@ -12,6 +16,24 @@ declare global {
         };
         dataLayer: {
             push: (event: { [key: string]: boolean | number | string; event: string }) => void;
+        };
+        fcSettings: {
+            [key: string]: unknown;
+        };
+        fcWidget: {
+            hide: VoidFunction;
+            isInitialized: () => boolean;
+            isLoaded: () => boolean;
+            on: (key: string, callback: VoidFunction) => void;
+            open: VoidFunction;
+            setConfig: (config: Record<string, Record<string, unknown>>) => void;
+            show: VoidFunction;
+            user: {
+                setLocale(locale: string): void;
+            };
+        };
+        fcWidgetMessengerConfig: {
+            config: Record<string, Record<string, unknown>>;
         };
     }
 }

--- a/global.d.ts
+++ b/global.d.ts
@@ -5,6 +5,7 @@ declare global {
         FreshChat: {
             initialize: (config: FreshChatConfig) => void;
         };
+        GrowthbookFeatures: { [key: string]: boolean };
         LC_API: {
             on_chat_ended: VoidFunction;
             open_chat_window: VoidFunction;
@@ -21,6 +22,7 @@ declare global {
             [key: string]: unknown;
         };
         fcWidget: {
+            close: VoidFunction;
             hide: VoidFunction;
             isInitialized: () => boolean;
             isLoaded: () => boolean;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
                 "@babel/preset-env": "^7.24.5",
                 "@chakra-ui/react": "^2.8.2",
                 "@datadog/browser-rum": "^5.11.0",
-                "@deriv-com/analytics": "^1.23.2",
+                "@deriv-com/analytics": "^1.26.1",
                 "@deriv-com/api-hooks": "^1.4.9",
                 "@deriv-com/auth-client": "1.0.27",
                 "@deriv-com/translations": "^1.3.9",
@@ -3795,9 +3795,10 @@
             }
         },
         "node_modules/@deriv-com/analytics": {
-            "version": "1.23.2",
-            "resolved": "https://registry.npmjs.org/@deriv-com/analytics/-/analytics-1.23.2.tgz",
-            "integrity": "sha512-r5SWpvM8/X+9c8ieJ9NIYnLtwNwsxhfKM/1SXwqfAQXkHtUKMreuG9xtGjbRoOx5kQsoKKmaso46wwJQuAhgaA==",
+            "version": "1.26.1",
+            "resolved": "https://registry.npmjs.org/@deriv-com/analytics/-/analytics-1.26.1.tgz",
+            "integrity": "sha512-cZKv+yd4TnAlidUfkf9esANaRQ1tw+UGKMaaLfpWXMbl7g+hnWfKV22nUfPv8UFqeshEfYfQvcfB6EQHmjVBMQ==",
+            "license": "MIT",
             "dependencies": {
                 "@growthbook/growthbook": "^1.1.0",
                 "@rudderstack/analytics-js": "^3.5.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "@babel/preset-env": "^7.24.5",
         "@chakra-ui/react": "^2.8.2",
         "@datadog/browser-rum": "^5.11.0",
-        "@deriv-com/analytics": "^1.23.2",
+        "@deriv-com/analytics": "^1.26.1",
         "@deriv-com/api-hooks": "^1.4.9",
         "@deriv-com/auth-client": "1.0.27",
         "@deriv-com/translations": "^1.3.9",

--- a/src/components/AppFooter/Livechat.tsx
+++ b/src/components/AppFooter/Livechat.tsx
@@ -15,6 +15,8 @@ const Livechat = () => {
     const freshChat = useFreshChat(token);
 
     setInterval(() => {
+        /*  This is for livechat last open state, 
+            once livechat is not loaded when freshchat is enabled then we can remove this */
         if (isFreshChatEnabled) {
             LiveChatWidget?.call('destroy');
         }

--- a/src/components/AppFooter/Livechat.tsx
+++ b/src/components/AppFooter/Livechat.tsx
@@ -1,5 +1,6 @@
 import { useGrowthbookGetFeatureValue, useLiveChat } from '@/hooks/custom-hooks';
 import useFreshChat from '@/hooks/custom-hooks/useFreshchat';
+import Chat from '@/utils/chat';
 import { LegacyLiveChatOutlineIcon } from '@deriv/quill-icons';
 import { useTranslations } from '@deriv-com/translations';
 import { Tooltip } from '@deriv-com/ui';
@@ -27,11 +28,7 @@ const Livechat = () => {
     }
 
     const showChat = () => {
-        if (isFreshChatEnabled) {
-            window?.fcWidget?.open();
-        } else {
-            LiveChatWidget.call('maximize');
-        }
+        Chat.open();
     };
 
     return (

--- a/src/components/AppFooter/__tests__/AppFooter.spec.tsx
+++ b/src/components/AppFooter/__tests__/AppFooter.spec.tsx
@@ -62,7 +62,7 @@ describe('AppFooter', () => {
 
     it('renders the footer elements', () => {
         render(<AppFooterComponent />);
-        expect(screen.getAllByRole('button')).toHaveLength(3);
+        expect(screen.getAllByRole('button')).toHaveLength(2);
         expect(screen.getAllByRole('link')).toHaveLength(5);
     });
 

--- a/src/components/AppHeader/MobileMenu/MobileMenuConfig.tsx
+++ b/src/components/AppHeader/MobileMenu/MobileMenuConfig.tsx
@@ -1,6 +1,8 @@
 import { ComponentProps, ReactNode } from 'react';
 import { ACCOUNT_LIMITS, HELP_CENTRE, RESPONSIBLE } from '@/constants';
-import { useLiveChat, useOAuth } from '@/hooks/custom-hooks';
+import { useOAuth } from '@/hooks/custom-hooks';
+import useFreshChat from '@/hooks/custom-hooks/useFreshchat';
+import Chat from '@/utils/chat';
 import {
     BrandDerivLogoCoralIcon,
     IconTypes,
@@ -36,7 +38,9 @@ type TMenuConfig = {
 export const MobileMenuConfig = () => {
     const { localize } = useTranslations();
     const { oAuthLogout } = useOAuth();
-    const { LiveChatWidget } = useLiveChat();
+
+    const token = localStorage.getItem('authToken') || null;
+    useFreshChat(token);
 
     const menuConfig: TMenuConfig[] = [
         [
@@ -115,7 +119,7 @@ export const MobileMenuConfig = () => {
                 label: localize('Live chat'),
                 LeftComponent: LegacyLiveChatOutlineIcon,
                 onClick: () => {
-                    LiveChatWidget.call('maximize');
+                    Chat.open();
                 },
             },
         ],

--- a/src/components/BlockedScenarios/BlockedScenarios.tsx
+++ b/src/components/BlockedScenarios/BlockedScenarios.tsx
@@ -1,4 +1,4 @@
-import { useLiveChat } from '@/hooks';
+import Chat from '@/utils/chat';
 import {
     DerivLightIcCashierBlockedIcon,
     DerivLightIcCashierLockedIcon,
@@ -20,7 +20,6 @@ type TBlockedScenariosObject = {
 
 const BlockedScenarios = ({ type }: { type: string }) => {
     const { isMobile } = useDevice();
-    const { LiveChatWidget } = useLiveChat();
 
     const buttonTextSize = isMobile ? 'md' : 'sm';
     const iconSize = isMobile ? 96 : 128;
@@ -31,7 +30,7 @@ const BlockedScenarios = ({ type }: { type: string }) => {
     };
 
     const openLiveChat = () => {
-        LiveChatWidget.call('maximize');
+        Chat.open();
     };
 
     const blockedScenarios: TBlockedScenariosObject = {

--- a/src/components/Modals/AdErrorTooltipModal/AdErrorTooltipModal.tsx
+++ b/src/components/Modals/AdErrorTooltipModal/AdErrorTooltipModal.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { ADVERT_TYPE, ERROR_CODES } from '@/constants';
-import { useLiveChat } from '@/hooks/custom-hooks';
 import { AdRateError } from '@/pages/my-ads/components';
+import Chat from '@/utils/chat';
 import { Localize } from '@deriv-com/translations';
 import { Button, Modal, Text, useDevice } from '@deriv-com/ui';
 import './AdErrorTooltipModal.scss';
@@ -89,9 +89,8 @@ const AdErrorTooltipModal = ({
     remainingAmount,
     visibilityStatus = [],
 }: TAdErrorTooltipModal) => {
-    const { LiveChatWidget } = useLiveChat();
     const onLiveChatClick = () => {
-        LiveChatWidget.call('maximize');
+        Chat.open();
     };
     const { isMobile } = useDevice();
     const textSize = isMobile ? 'md' : 'sm';

--- a/src/components/Modals/AdVisibilityErrorModal/AdVisibilityErrorModal.tsx
+++ b/src/components/Modals/AdVisibilityErrorModal/AdVisibilityErrorModal.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react';
 import { TCurrency } from 'types';
 import { ERROR_CODES } from '@/constants';
-import { useLiveChat } from '@/hooks';
+import Chat from '@/utils/chat';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Button, Modal, Text, useDevice } from '@deriv-com/ui';
 import './AdVisibilityErrorModal.scss';
@@ -84,12 +84,11 @@ const AdVisibilityErrorModal = ({
     onRequestClose,
 }: TAdVisibilityErrorModalProps) => {
     const { localize } = useTranslations();
-    const { LiveChatWidget } = useLiveChat();
     const { isDesktop } = useDevice();
     const textSize = isDesktop ? 'sm' : 'md';
 
     const onLiveChatClick = () => {
-        LiveChatWidget.call('maximize');
+        Chat.open();
     };
 
     return (

--- a/src/components/Modals/AdVisibilityErrorModal/__tests__/AdVisibilityErrorModal.spec.tsx
+++ b/src/components/Modals/AdVisibilityErrorModal/__tests__/AdVisibilityErrorModal.spec.tsx
@@ -1,5 +1,5 @@
 import { TCurrency } from 'types';
-import { useLiveChat } from '@/hooks';
+import Chat from '@/utils/chat';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import AdVisibilityErrorModal from '../AdVisibilityErrorModal';
@@ -17,25 +17,21 @@ jest.mock('@deriv-com/ui', () => ({
     useDevice: () => ({ isMobile: false }),
 }));
 
-const mockFn = jest.fn();
-
-jest.mock('@/hooks', () => ({
-    ...jest.requireActual('@/hooks'),
-    useLiveChat: jest.fn().mockReturnValue({ LiveChatWidget: {} }),
-}));
+jest.spyOn(Chat, 'open').mockImplementation(() => Promise.resolve());
 
 describe('AdVisibilityErrorModal', () => {
     it('should render the modal as expected for advertiser balance error', () => {
         render(<AdVisibilityErrorModal {...mockProps} />);
         expect(screen.getByText('Your ad isn’t visible to others')).toBeInTheDocument();
     });
-    it('should open live chat for clicking on live chat text for advertiser daily limit error', async () => {
-        (useLiveChat as jest.Mock).mockReturnValue({ LiveChatWidget: { call: mockFn } });
+    it('should open live chat when clicking on live chat text for advertiser daily limit error', async () => {
         render(<AdVisibilityErrorModal {...mockProps} errorCode='advertiser_daily_limit' />);
         expect(screen.getByText('Your ad is not listed on')).toBeInTheDocument();
         const liveChatButton = screen.getByRole('button', { name: 'live chat' });
+
         await userEvent.click(liveChatButton);
-        expect(mockFn).toHaveBeenCalledTimes(1);
+
+        expect(Chat.open).toHaveBeenCalledTimes(1);
     });
     it('should close the modal on clicking ok', async () => {
         render(<AdVisibilityErrorModal {...mockProps} />);

--- a/src/components/Modals/OrderDetailsComplainModal/OrderDetailsComplainModal.tsx
+++ b/src/components/Modals/OrderDetailsComplainModal/OrderDetailsComplainModal.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { THooks } from 'types';
 import { FullPageMobileWrapper } from '@/components/FullPageMobileWrapper';
-import { api, useLiveChat } from '@/hooks';
+import { api } from '@/hooks';
+import Chat from '@/utils/chat';
 import { Localize } from '@deriv-com/translations';
 import { Button, Modal, Text, useDevice } from '@deriv-com/ui';
 import { OrderDetailsComplainModalRadioGroup } from './OrderDetailsComplainModalRadioGroup';
@@ -74,12 +75,11 @@ const OrderDetailsComplainModal = ({
     onRequestClose,
 }: TOrderDetailsComplainModal) => {
     const { isDesktop } = useDevice();
-    const { LiveChatWidget } = useLiveChat();
     const [disputeReason, setDisputeReason] = useState('');
     const { isSuccess, mutate } = api.orderDispute.useDispute();
 
     const onLiveChatClick = () => {
-        LiveChatWidget.call('maximize');
+        Chat.open();
         onRequestClose();
     };
 

--- a/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -28,6 +28,7 @@ const OnboardingTooltip = ({
     title,
 }: TOnboardingTooltipProps) => {
     const [isOnboardingTooltipVisible, setIsOnboardingTooltipVisible] = useState<boolean>(
+        // @ts-expect-error - localStorageItemName is a string and TLocalStorageKeys is not exported
         LocalStorageUtils.getValue(localStorageItemName) ?? true
     );
 
@@ -44,6 +45,7 @@ const OnboardingTooltip = ({
     });
 
     useEffect(() => {
+        // @ts-expect-error - localStorageItemName is a string and TLocalStorageKeys is not exported
         LocalStorageUtils.setValue<boolean>(localStorageItemName, false);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/components/OnboardingTooltip/OnboardingTooltip.tsx
+++ b/src/components/OnboardingTooltip/OnboardingTooltip.tsx
@@ -28,7 +28,6 @@ const OnboardingTooltip = ({
     title,
 }: TOnboardingTooltipProps) => {
     const [isOnboardingTooltipVisible, setIsOnboardingTooltipVisible] = useState<boolean>(
-        // @ts-expect-error - localStorageItemName is a string and TLocalStorageKeys is not exported
         LocalStorageUtils.getValue(localStorageItemName) ?? true
     );
 
@@ -45,7 +44,6 @@ const OnboardingTooltip = ({
     });
 
     useEffect(() => {
-        // @ts-expect-error - localStorageItemName is a string and TLocalStorageKeys is not exported
         LocalStorageUtils.setValue<boolean>(localStorageItemName, false);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);

--- a/src/hooks/custom-hooks/useDerivAnalytics.ts
+++ b/src/hooks/custom-hooks/useDerivAnalytics.ts
@@ -1,5 +1,6 @@
 import Cookies from 'js-cookie';
 import { FIREBASE_INIT_DATA } from '@/constants';
+import getCountry from '@/utils/get-country';
 import { Analytics } from '@deriv-com/analytics';
 import { useWebsiteStatus } from '@deriv-com/api-hooks';
 import { useDevice } from '@deriv-com/ui';
@@ -38,33 +39,32 @@ const useDerivAnalytics = () => {
                           utm_source: 'no source',
                       };
 
-                Analytics.initialise({
+                const config = {
                     growthbookDecryptionKey: services?.marketing_growthbook
                         ? process.env.VITE_GROWTHBOOK_DECRYPTION_KEY
                         : undefined,
                     growthbookKey: services?.marketing_growthbook ? process.env.VITE_GROWTHBOOK_CLIENT_KEY : undefined,
                     growthbookOptions: {
+                        attributes: {
+                            account_type: activeAccount?.account_type || 'unlogged',
+                            app_id: String(WebSocketUtils.getAppId()),
+                            country: await getCountry(),
+                            device_language: navigator?.language || 'en-EN',
+                            device_type: isMobile ? 'mobile' : 'desktop',
+                            domain: window.location.hostname,
+                            url: window.location.href,
+                            user_language: currentLang.toLowerCase(),
+                            utm_campaign: ppcCampaignCookies?.utm_campaign,
+                            utm_content: ppcCampaignCookies?.utm_content,
+                            utm_medium: ppcCampaignCookies?.utm_medium,
+                            utm_source: ppcCampaignCookies?.utm_source,
+                        },
                         disableCache: !isProduction,
                     },
                     rudderstackKey: services?.tracking_rudderstack ? process.env.VITE_RUDDERSTACK_KEY || '' : '',
-                });
+                };
 
-                await Analytics?.getInstances()?.ab?.GrowthBook?.init();
-                Analytics.setAttributes({
-                    account_type: activeAccount?.account_type || 'unlogged',
-                    app_id: String(WebSocketUtils.getAppId()),
-                    country:
-                        JSON.parse(Cookies.get('website_status') || '{}')?.clients_country ||
-                        websiteStatus?.clients_country,
-                    device_language: navigator?.language || 'en-EN',
-                    device_type: isMobile ? 'mobile' : 'desktop',
-                    domain: window.location.hostname,
-                    user_language: currentLang.toLowerCase(),
-                    utm_campaign: ppcCampaignCookies?.utm_campaign,
-                    utm_content: ppcCampaignCookies?.utm_content,
-                    utm_medium: ppcCampaignCookies?.utm_medium,
-                    utm_source: ppcCampaignCookies?.utm_source,
-                });
+                await Analytics.initialise(config);
             }
         } catch (error) {
             // eslint-disable-next-line no-console

--- a/src/hooks/custom-hooks/useFreshchat.ts
+++ b/src/hooks/custom-hooks/useFreshchat.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { useScript } from 'usehooks-ts';
+
+const useFreshChat = (token: string | null) => {
+    const scriptStatus = useScript('https://static.deriv.com/scripts/freshchat.js');
+    const [isReady, setIsReady] = useState(false);
+    const language = localStorage.getItem('i18n_language') || 'EN';
+
+    useEffect(() => {
+        const checkFcWidget = (intervalId: NodeJS.Timeout) => {
+            if (typeof window !== 'undefined') {
+                if (window.fcWidget?.isInitialized() == true && !isReady) {
+                    // window.fcWidget?.user.setLocale(language.toLowerCase());
+                    setIsReady(true);
+                    clearInterval(intervalId);
+                }
+            }
+        };
+
+        const initFreshChat = async () => {
+            if (scriptStatus === 'ready' && window.FreshChat && window.fcSettings) {
+                window.FreshChat.initialize({
+                    hideButton: true,
+                    token,
+                });
+
+                const intervalId = setInterval(() => checkFcWidget(intervalId), 500);
+
+                return () => clearInterval(intervalId);
+            }
+        };
+
+        initFreshChat();
+    }, [isReady, language, scriptStatus, token]);
+
+    return {
+        isReady,
+        widget: window.fcWidget,
+    };
+};
+
+export default useFreshChat;

--- a/src/hooks/custom-hooks/useFreshchat.ts
+++ b/src/hooks/custom-hooks/useFreshchat.ts
@@ -10,7 +10,6 @@ const useFreshChat = (token: string | null) => {
         const checkFcWidget = (intervalId: NodeJS.Timeout) => {
             if (typeof window !== 'undefined') {
                 if (window.fcWidget?.isInitialized() == true && !isReady) {
-                    // window.fcWidget?.user.setLocale(language.toLowerCase());
                     setIsReady(true);
                     clearInterval(intervalId);
                 }
@@ -24,7 +23,7 @@ const useFreshChat = (token: string | null) => {
                     token,
                 });
 
-                const intervalId = setInterval(() => checkFcWidget(intervalId), 500);
+                const intervalId: NodeJS.Timeout = setInterval(() => checkFcWidget(intervalId), 500);
 
                 return () => clearInterval(intervalId);
             }

--- a/src/hooks/custom-hooks/useGrowthbookGetFeatureValue.tsx
+++ b/src/hooks/custom-hooks/useGrowthbookGetFeatureValue.tsx
@@ -20,6 +20,10 @@ const useGrowthbookGetFeatureValue = <T,>({
     const isGBLoaded = useIsGrowthbookIsLoaded();
 
     useEffect(() => {
+        if (typeof window !== 'undefined') {
+            window.Analytics = Analytics;
+        }
+
         if (isGBLoaded) {
             if (Analytics?.getInstances()?.ab) {
                 const setFeatureValue = () => {

--- a/src/hooks/custom-hooks/useGrowthbookGetFeatureValue.tsx
+++ b/src/hooks/custom-hooks/useGrowthbookGetFeatureValue.tsx
@@ -1,45 +1,36 @@
 import { useEffect, useState } from 'react';
+import getFeatureFlag from '@/utils/get-featureflag';
 import { Analytics } from '@deriv-com/analytics';
-import useIsGrowthbookIsLoaded from './useIsGrowthbookLoaded';
 
-type featureValueTypes = Record<string, boolean> | boolean | string | [];
-
-interface UseGrowthbookGetFeatureValueArgs {
-    defaultValue?: featureValueTypes;
+interface UseGrowthbookGetFeatureValueArgs<T> {
+    defaultValue?: T;
     featureFlag: string;
 }
 
-const useGrowthbookGetFeatureValue = <T,>({
+const useGrowthbookGetFeatureValue = <T extends boolean | string>({
     defaultValue,
     featureFlag,
-}: UseGrowthbookGetFeatureValueArgs): [T, boolean] => {
-    const resolvedDefaultValue: featureValueTypes = defaultValue !== undefined ? defaultValue : false;
-    const [featureFlagValue, setFeatureFlagValue] = useState<T>(
-        (Analytics?.getFeatureValue(featureFlag, resolvedDefaultValue) ?? resolvedDefaultValue) as T
-    );
-    const isGBLoaded = useIsGrowthbookIsLoaded();
+}: UseGrowthbookGetFeatureValueArgs<T>) => {
+    const resolvedDefaultValue: T = defaultValue !== undefined ? defaultValue : (false as T);
+    const [featureFlagValue, setFeatureFlagValue] = useState<boolean>(false);
+    const [isGBLoaded, setIsGBLoaded] = useState(false);
+
+    // Required for debugging Growthbook, this will be removed after this is added in the Analytics directly.
+    if (typeof window !== 'undefined') {
+        window.Analytics = Analytics;
+    }
 
     useEffect(() => {
-        if (typeof window !== 'undefined') {
-            window.Analytics = Analytics;
-        }
+        const fetchFeatureFlag = async () => {
+            const isEnabled = await getFeatureFlag(featureFlag, resolvedDefaultValue);
+            setFeatureFlagValue(isEnabled);
+            setIsGBLoaded(true);
+        };
 
-        if (isGBLoaded) {
-            if (Analytics?.getInstances()?.ab) {
-                const setFeatureValue = () => {
-                    const value = Analytics?.getFeatureValue(featureFlag, resolvedDefaultValue) as T;
-                    setFeatureFlagValue(value);
-                };
-                setFeatureValue();
-                Analytics?.getInstances()?.ab?.GrowthBook?.setRenderer(() => {
-                    // this will be called whenever the feature flag value changes and acts as a event listener
-                    setFeatureValue();
-                });
-            }
-        }
-    }, [isGBLoaded, resolvedDefaultValue, featureFlag]);
+        fetchFeatureFlag();
+    }, []);
 
-    return [featureFlagValue as T, isGBLoaded];
+    return [featureFlagValue, isGBLoaded];
 };
 
 export default useGrowthbookGetFeatureValue;

--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -15,9 +15,9 @@ type UseOAuthReturn = {
  * @returns {UseOAuthReturn}
  */
 const useOAuth = (): UseOAuthReturn => {
-    const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<TOAuth2EnabledAppList>({
+    const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<string>({
         featureFlag: 'hydra_be',
-    });
+    }) as unknown as [TOAuth2EnabledAppList, boolean];
 
     const oAuthGrowthbookConfig = {
         OAuth2EnabledApps,

--- a/src/hooks/custom-hooks/useOAuth2Enabled.ts
+++ b/src/hooks/custom-hooks/useOAuth2Enabled.ts
@@ -20,9 +20,9 @@ type hydraBEApps = [
  * @returns [boolean]
  */
 const useOAuth2Enabled = () => {
-    const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<hydraBEApps>({
+    const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<string>({
         featureFlag: 'hydra_be',
-    });
+    }) as unknown as [hydraBEApps, boolean];
     const [isOauth2Enabled, setIsOauth2Enabled] = useState<boolean>(false);
     const { appId } = getServerInfo();
 

--- a/src/pages/guide/screens/Awareness/Awareness.tsx
+++ b/src/pages/guide/screens/Awareness/Awareness.tsx
@@ -1,11 +1,10 @@
-import { useLiveChat } from '@/hooks/custom-hooks';
+import Chat from '@/utils/chat';
 import { DerivDarkScamAdvancePaymentIcon, DerivDarkScamPotIcon, DerivDarkScamSmsIcon } from '@deriv/quill-icons';
 import { Localize } from '@deriv-com/translations';
 import { Text, useDevice } from '@deriv-com/ui';
 import { Carousel } from '../../components';
 
 const Awareness = () => {
-    const { LiveChatWidget } = useLiveChat();
     const { isDesktop } = useDevice();
 
     return (
@@ -55,7 +54,7 @@ const Awareness = () => {
                                             className='guide__content-section--link'
                                             key={0}
                                             onClick={() => {
-                                                LiveChatWidget.call('maximize');
+                                                Chat.open();
                                             }}
                                         />,
                                     ]}

--- a/src/pages/guide/screens/FAQs/FAQs.tsx
+++ b/src/pages/guide/screens/FAQs/FAQs.tsx
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import { useLiveChat } from '@/hooks/custom-hooks';
+import Chat from '@/utils/chat';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Accordion, Text, useDevice } from '@deriv-com/ui';
 import { URLConstants } from '@deriv-com/utils';
@@ -10,7 +10,6 @@ type TFAQsProps = {
 };
 
 const FAQs = ({ guideContentRef }: TFAQsProps) => {
-    const { LiveChatWidget } = useLiveChat();
     const { isDesktop } = useDevice();
     const { localize } = useTranslations();
     const accordionRefs = useRef<HTMLDivElement[]>([]);
@@ -149,7 +148,7 @@ const FAQs = ({ guideContentRef }: TFAQsProps) => {
                                 className='guide__content-section--link'
                                 key={0}
                                 onClick={() => {
-                                    LiveChatWidget.call('maximize');
+                                    Chat.open();
                                 }}
                             />,
                         ]}

--- a/src/pages/guide/screens/GettingStarted/GettingStarted.tsx
+++ b/src/pages/guide/screens/GettingStarted/GettingStarted.tsx
@@ -1,4 +1,4 @@
-import { useLiveChat } from '@/hooks/custom-hooks';
+import Chat from '@/utils/chat';
 import {
     DerivDarkFindAdIcon,
     DerivDarkPayUserIcon,
@@ -11,7 +11,6 @@ import { Tab, Tabs, Text } from '@deriv-com/ui';
 import { Carousel } from '../../components';
 
 const GettingStarted = () => {
-    const { LiveChatWidget } = useLiveChat();
     const { localize } = useTranslations();
 
     return (
@@ -57,7 +56,7 @@ const GettingStarted = () => {
                                                     className='guide__content-section--link'
                                                     key={0}
                                                     onClick={() => {
-                                                        LiveChatWidget.call('maximize');
+                                                        Chat.open();
                                                     }}
                                                 />,
                                             ]}

--- a/src/utils/__tests__/chat.spec.ts
+++ b/src/utils/__tests__/chat.spec.ts
@@ -1,0 +1,59 @@
+import Chat from '../chat';
+import getFeatureFlag from '../get-featureflag';
+
+jest.mock('../getFeatureFlag');
+
+describe('Chat Utility', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).fcWidget = {
+            close: jest.fn(),
+            open: jest.fn(),
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).LiveChatWidget = {
+            call: jest.fn(),
+        };
+    });
+
+    describe('open method', () => {
+        it('should call fcWidget.open when Freshchat is enabled', async () => {
+            (getFeatureFlag as jest.Mock).mockResolvedValueOnce(true);
+
+            await Chat.open();
+
+            expect(window.fcWidget.open).toHaveBeenCalled();
+            expect(window.LiveChatWidget.call).not.toHaveBeenCalled();
+        });
+
+        it('should call LiveChatWidget.call with "maximize" when Freshchat is disabled', async () => {
+            (getFeatureFlag as jest.Mock).mockResolvedValueOnce(false);
+
+            await Chat.open();
+
+            expect(window.fcWidget.open).not.toHaveBeenCalled();
+            expect(window.LiveChatWidget.call).toHaveBeenCalledWith('maximize');
+        });
+    });
+
+    describe('close method', () => {
+        it('should call fcWidget.close when Freshchat is enabled', async () => {
+            (getFeatureFlag as jest.Mock).mockResolvedValueOnce(true);
+
+            await Chat.close();
+
+            expect(window.fcWidget.close).toHaveBeenCalled();
+            expect(window.LiveChatWidget.call).not.toHaveBeenCalled();
+        });
+
+        it('should call LiveChatWidget.call with "minimize" when Freshchat is disabled', async () => {
+            (getFeatureFlag as jest.Mock).mockResolvedValueOnce(false);
+
+            await Chat.close();
+
+            expect(window.fcWidget.close).not.toHaveBeenCalled();
+            expect(window.LiveChatWidget.call).toHaveBeenCalledWith('hide');
+        });
+    });
+});

--- a/src/utils/__tests__/chat.spec.ts
+++ b/src/utils/__tests__/chat.spec.ts
@@ -1,7 +1,7 @@
 import Chat from '../chat';
 import getFeatureFlag from '../get-featureflag';
 
-jest.mock('../getFeatureFlag');
+jest.mock('../get-featureflag');
 
 describe('Chat Utility', () => {
     beforeEach(() => {

--- a/src/utils/__tests__/get-country.spec.ts
+++ b/src/utils/__tests__/get-country.spec.ts
@@ -1,0 +1,36 @@
+import getCountry from '../get-country';
+
+describe('getCountry', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn() as jest.Mock;
+    });
+
+    afterEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should return the country code in lowercase when available', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            text: async () => 'loc=US\nother=info\n',
+        });
+
+        const country = await getCountry();
+        expect(country).toBe('us');
+    });
+
+    it('should return an empty string if the loc field is not present', async () => {
+        (global.fetch as jest.Mock).mockResolvedValue({
+            text: async () => 'other=info\n',
+        });
+
+        const country = await getCountry();
+        expect(country).toBe('');
+    });
+
+    it('should return an empty string if the fetch fails', async () => {
+        (global.fetch as jest.Mock).mockRejectedValue(new Error('Fetch failed'));
+
+        const country = await getCountry();
+        expect(country).toBe('');
+    });
+});

--- a/src/utils/__tests__/get-featureflag.spec.ts
+++ b/src/utils/__tests__/get-featureflag.spec.ts
@@ -1,0 +1,74 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Analytics } from '@deriv-com/analytics';
+import getFeatureFlag from '../get-featureflag';
+
+// Mock the @deriv-com/analytics module
+jest.mock('@deriv-com/analytics', () => ({
+    Analytics: {
+        getFeatureValue: jest.fn(),
+        getGrowthbookStatus: jest.fn(),
+        getInstances: jest.fn(),
+    },
+}));
+
+describe('getFeatureFlag', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).GrowthbookFeatures = {}; // Type assertion for window
+    });
+
+    it('should return cached feature flag value if already defined in window.GrowthbookFeatures', async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (window as any).GrowthbookFeatures.feature_flag = true;
+
+        const result = await getFeatureFlag('feature_flag');
+
+        expect(result).toBe(true);
+        expect(Analytics.getInstances).not.toHaveBeenCalled();
+    });
+
+    it('should return feature flag value based on GrowthBook status and feature availability', async () => {
+        (Analytics.getInstances as jest.Mock).mockReturnValueOnce({ ab: {} });
+        (Analytics.getGrowthbookStatus as jest.Mock).mockResolvedValueOnce({
+            isLoaded: true,
+            status: { success: true },
+        });
+        (Analytics.getFeatureValue as jest.Mock).mockReturnValueOnce(true);
+
+        const result = await getFeatureFlag('feature_flag');
+
+        expect(result).toBe(true);
+        expect(Analytics.getFeatureValue).toHaveBeenCalledWith('feature_flag', false);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((window as any).GrowthbookFeatures.feature_flag).toBe(true);
+    });
+
+    it('should return the defaultValue if provided and GrowthBook feature is unavailable', async () => {
+        (Analytics.getInstances as jest.Mock).mockReturnValueOnce({ ab: {} });
+        (Analytics.getGrowthbookStatus as jest.Mock).mockResolvedValueOnce({
+            isLoaded: true,
+            status: { success: true },
+        });
+        (Analytics.getFeatureValue as jest.Mock).mockReturnValueOnce(false);
+
+        const result = await getFeatureFlag('feature_flag', true);
+
+        expect(result).toBe(false);
+        expect(Analytics.getFeatureValue).toHaveBeenCalledWith('feature_flag', true);
+    });
+
+    it('should return false if GrowthBook config encounters issues', async () => {
+        (Analytics.getInstances as jest.Mock).mockReturnValueOnce({ ab: {} });
+        (Analytics.getGrowthbookStatus as jest.Mock).mockResolvedValueOnce({
+            isLoaded: true,
+            status: { success: false },
+        });
+
+        const result = await getFeatureFlag('feature_flag');
+
+        expect(result).toBe(false);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((window as any).GrowthbookFeatures.feature_flag).toBe(false);
+    });
+});

--- a/src/utils/chat.ts
+++ b/src/utils/chat.ts
@@ -1,0 +1,16 @@
+/* This utility function is responsible to pop out currently
+ enabled widget based on growthbook feature flag */
+
+import getFeatureFlag from './get-featureflag';
+
+const Chat = {
+    close: async () => {
+        (await Chat.isFreshChat()) ? window.fcWidget?.close() : window.LiveChatWidget?.call('hide');
+    },
+    isFreshChat: async () => getFeatureFlag('enable_freshworks_live_chat_p2p'),
+    open: async () => {
+        (await Chat.isFreshChat()) ? window.fcWidget?.open() : window.LiveChatWidget?.call('maximize');
+    },
+};
+
+export default Chat;

--- a/src/utils/get-country.ts
+++ b/src/utils/get-country.ts
@@ -1,0 +1,15 @@
+import Cookies from 'js-cookie';
+
+const getCountry = async () => {
+    try {
+        const response = await fetch('https://www.cloudflare.com/cdn-cgi/trace').catch(() => null);
+        const text = response ? await response.text().catch(() => '') : '';
+        const entries = text ? text.split('\n').map(v => v.split('=', 2)) : [];
+        const data = entries.length ? Object.fromEntries(entries) : {};
+        return data?.loc?.toLowerCase() || JSON.parse(Cookies.get('website_status') || '') || '';
+    } catch {
+        return '';
+    }
+};
+
+export default getCountry;

--- a/src/utils/get-featureflag.ts
+++ b/src/utils/get-featureflag.ts
@@ -1,0 +1,64 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { Analytics } from '@deriv-com/analytics';
+
+const waitForGrowthbook = () => {
+    return new Promise(resolve => {
+        const startTime = Date.now();
+
+        const checkAnalytics = async () => {
+            // This is a fallback incase growthbook experience an error and never gets loaded
+            if (Date.now() - startTime >= 10000) {
+                resolve(false);
+                return;
+            }
+
+            if (typeof Analytics !== 'undefined') {
+                if (Analytics.getInstances()?.ab !== undefined) {
+                    resolve(true);
+                } else {
+                    const gbState = await Analytics?.getGrowthbookStatus();
+
+                    if (gbState?.isLoaded) {
+                        resolve(true);
+                    } else {
+                        setTimeout(checkAnalytics, 50);
+                    }
+                }
+            } else {
+                setTimeout(checkAnalytics, 50);
+            }
+        };
+
+        checkAnalytics();
+    });
+};
+
+const getFeatureFlag = async (feature: string, defaultValue?: boolean | string | undefined) => {
+    let enabled = false;
+
+    if (typeof window?.GrowthbookFeatures === 'undefined') {
+        window.GrowthbookFeatures = {};
+    }
+
+    // Avoid rechecks and return previous result immediately
+    if (typeof window.GrowthbookFeatures[feature] !== 'undefined') {
+        return window.GrowthbookFeatures[feature];
+    }
+
+    const isSuccessfullyLoaded = await waitForGrowthbook();
+
+    if (Analytics && Analytics?.getGrowthbookStatus && isSuccessfullyLoaded) {
+        const gbState = await Analytics?.getGrowthbookStatus();
+
+        // If Growthbook has config error, down or encountering issues, feature flag will default to false
+        if (gbState.isLoaded && gbState.status?.success) {
+            enabled = Analytics?.getFeatureValue(feature, !!defaultValue);
+        }
+    }
+
+    window.GrowthbookFeatures[feature] = enabled;
+
+    return enabled;
+};
+
+export default getFeatureFlag;


### PR DESCRIPTION
- Initial implementation of Freshchat
- Updated growthbook config
- Client's `country` is standardized via `cloudflare` for proper trigger of growthbook flag


`Note:` I need help for initial review, this is awaiting for the new hooks coming from deriv-app to properly handle the toggle of the current active chat widget. 