### PR TITLE
Ameerul / P2PS-4384 Some Payment method is not showing on Sell order modal

### DIFF
--- a/src/components/BuySellForm/BuySellForm.tsx
+++ b/src/components/BuySellForm/BuySellForm.tsx
@@ -132,6 +132,10 @@ const BuySellForm = ({ advertId, isModalOpen, onRequestClose }: TBuySellFormProp
         };
     });
 
+    const filteredAdvertiserPaymentMethods = advertiserPaymentMethods?.filter(method =>
+        paymentMethodNames?.includes(method.display_name || '')
+    );
+
     const history = useHistory();
     const { isDesktop } = useDevice();
     const isBuy = type === BUY_SELL.BUY;
@@ -343,7 +347,7 @@ const BuySellForm = ({ advertId, isModalOpen, onRequestClose }: TBuySellFormProp
                 <LightDivider />
                 {isBuy && paymentMethodNames && paymentMethodNames?.length > 0 && (
                     <BuySellPaymentSection
-                        advertiserPaymentMethods={advertiserPaymentMethods as TPaymentMethod[]}
+                        advertiserPaymentMethods={filteredAdvertiserPaymentMethods as TPaymentMethod[]}
                         availablePaymentMethods={availablePaymentMethods as TPaymentMethod[]}
                         isDisabled={shouldDisableField}
                         onSelectPaymentMethodCard={onSelectPaymentMethodCard}

--- a/src/components/BuySellForm/BuySellPaymentSection/BuySellPaymentSection.tsx
+++ b/src/components/BuySellForm/BuySellPaymentSection/BuySellPaymentSection.tsx
@@ -26,7 +26,8 @@ const BuySellPaymentSection = ({
     setIsHidden,
 }: TBuySellPaymentSectionProps) => {
     const { isDesktop } = useDevice();
-    const sortedList = sortPaymentMethodsWithAvailability(availablePaymentMethods);
+    const sortedList = sortPaymentMethodsWithAvailability(availablePaymentMethods).filter(p => !p.isAvailable);
+    const disableAdvertiserPaymentMethods = selectedPaymentMethodIds.length === 3;
     const { localize } = useTranslations();
 
     const [formState, dispatch] = useReducer(
@@ -67,6 +68,20 @@ const BuySellPaymentSection = ({
                     )}
                 </Text>
                 <div className='flex gap-[0.8rem] flex-wrap'>
+                    {advertiserPaymentMethods?.map((paymentMethod, index) => {
+                        const isSelected = selectedPaymentMethodIds.includes(Number(paymentMethod.id));
+
+                        return (
+                            <PaymentMethodCard
+                                isDisabled={isDisabled || (disableAdvertiserPaymentMethods && !isSelected)}
+                                key={index}
+                                medium
+                                onSelectPaymentMethodCard={onSelectPaymentMethodCard}
+                                paymentMethod={paymentMethod}
+                                selectedPaymentMethodIds={selectedPaymentMethodIds}
+                            />
+                        );
+                    })}
                     {sortedList?.map((paymentMethod, index) => (
                         <PaymentMethodCard
                             isDisabled={isDisabled}

--- a/src/components/BuySellForm/BuySellPaymentSection/__tests__/BuySellPaymentSection.spec.tsx
+++ b/src/components/BuySellForm/BuySellPaymentSection/__tests__/BuySellPaymentSection.spec.tsx
@@ -61,12 +61,10 @@ describe('<BuySellPaymentSection />', () => {
         render(<BuySellPaymentSection {...mockProps} />);
         expect(screen.getByText('Receive payment to')).toBeInTheDocument();
     });
-    it('should render the payment method cards when there are available payment methods', async () => {
-        render(<BuySellPaymentSection {...mockProps} availablePaymentMethods={[mockAvailablePaymentMethods]} />);
+    it('should render the payment method cards when there are advertiser payment methods', async () => {
+        render(<BuySellPaymentSection {...mockProps} advertiserPaymentMethods={[mockAvailablePaymentMethods]} />);
         expect(screen.getByText('Receive payment to')).toBeInTheDocument();
-        expect(
-            screen.getByText('To place an order, add one of the advertiser’s preferred payment methods:')
-        ).toBeInTheDocument();
+        expect(screen.getByText('You may choose up to 3.')).toBeInTheDocument();
         expect(screen.getByText('Other')).toBeInTheDocument();
         const checkbox = screen.getByRole('checkbox');
         await userEvent.click(checkbox);


### PR DESCRIPTION
- Filtered out available payment methods and return only the non available ones to handle showing the pm add cards
- Mapped out advertiser payment methods to ensure all payment methods are shown in Sell Order screen
- Added small logic to disable payment method card selection if user has already selected more than 3 payment methods


https://github.com/user-attachments/assets/b19fc527-2904-43ba-91ac-2fab456d6e3d


https://github.com/user-attachments/assets/a4159351-6b99-4468-9f61-892305fc7f3d

