### PR TITLE
added vercel.json to fix vercel dr publish

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+    "routes": [
+        { "handle": "filesystem" },
+        {
+            "src": "/(.*)",
+            "dest": "/index.html"
+        }
+    ]
+}


### PR DESCRIPTION
# Add vercel.json for SPA routing configuration

## Description
Added `vercel.json` to handle client-side routing in our Single Page Application (SPA) when deployed to Vercel. This configuration ensures that all routes are properly handled and prevents 404 errors when accessing paths directly or refreshing pages.

## Changes
- Added `vercel.json` with route configuration to redirect all requests to index.html
- Enables proper functioning of client-side routing
- Fixes 404 errors on direct access to routes or page refreshes

## Screenshots

<img width="1714" alt="Screenshot 2024-12-09 at 4 30 20 PM" src="https://github.com/user-attachments/assets/e46bbe1e-8d83-4798-b782-d45b922e3283">
