### PR TITLE
updated vercel.dr.json

### DIFF
--- a/vercel.dr.json
+++ b/vercel.dr.json
@@ -1,5 +1,10 @@
 {
-    "cleanUrls": true,
     "outputDirectory": "dist",
-    "buildCommand": "echo ✅  Skipping build to use existing built files"
+    "buildCommand": "echo ✅  Skipping build to use existing built files",
+    "rewrites": [
+        {
+            "source": "/(.*)",
+            "destination": "/index.html"
+        }
+    ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,9 +1,0 @@
-{
-    "routes": [
-        { "handle": "filesystem" },
-        {
-            "src": "/(.*)",
-            "dest": "/index.html"
-        }
-    ]
-}


### PR DESCRIPTION
## Problem
Previous configuration with `routes` in `vercel.json` wasn't working with production deployment because the shared action (`vercel_DR_publish`) was overwriting it with `vercel.dr.json`. 

## Solution
- Modified `vercel.dr.json` to include both build settings and SPA routing configuration
- Used `rewrites` instead of `routes` for better compatibility
- Removed `cleanUrls` as it was causing 404 errors on subpages when combined with `rewrites`
