### PR TITLE
Ameerul / WEBREL-3442 On Redirection to from traders hub to P2P the P2P page shows infinite loading screen

### DIFF
--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -49,7 +49,8 @@ const useOAuth = (): UseOAuthReturn => {
                 const authTokenCookie = Cookies.get('authtoken');
 
                 if (from === 'tradershub' && authTokenCookie) {
-                    localStorage.setItem('authToken', authTokenCookie);
+                    const cleanedAuthToken = decodeURIComponent(authTokenCookie).replace(/^"|"$/g, '');
+                    localStorage.setItem('authToken', cleanedAuthToken);
                     Cookies.remove('authtoken');
                     window.location.href = window.location.origin;
                 }


### PR DESCRIPTION
- Cleaned the authtoken cookie (removed quotes) and store it in localstorage