### PR TITLE
farrah/chore: update quill icons version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "@deriv-com/translations": "^1.3.9",
                 "@deriv-com/ui": "^1.35.6",
                 "@deriv-com/utils": "^0.0.39",
-                "@deriv/quill-icons": "^2.1.2",
+                "@deriv/quill-icons": "^2.3.0",
                 "@sendbird/chat": "^4.11.3",
                 "@tanstack/react-query": "^5.28.14",
                 "@tanstack/react-table": "^8.15.0",
@@ -3962,9 +3962,9 @@
             }
         },
         "node_modules/@deriv/quill-icons": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.1.2.tgz",
-            "integrity": "sha512-CUiItM0SkN5jRfy1cM0SF5ATg8ClCjGhVDY2f6YXh5n1HBPftCN3KoB/OTVckkFjcoR8morS1WGwHC41sa7BBg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/@deriv/quill-icons/-/quill-icons-2.3.0.tgz",
+            "integrity": "sha512-rjVQiP87XyGz45Xm9xfoKRfPUTrrsrFGknON+d7OSD5pIhNtDJSRZSnNgCHm84HDBbXxt1mQdxzSF7zYW2mHGA==",
             "peerDependencies": {
                 "react": ">= 16",
                 "react-dom": ">= 16"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@deriv-com/translations": "^1.3.9",
         "@deriv-com/ui": "^1.35.6",
         "@deriv-com/utils": "^0.0.39",
-        "@deriv/quill-icons": "^2.1.2",
+        "@deriv/quill-icons": "^2.3.0",
         "@sendbird/chat": "^4.11.3",
         "@tanstack/react-query": "^5.28.14",
         "@tanstack/react-table": "^8.15.0",


### PR DESCRIPTION
Update quill-icons version to get the missing eUSDT icon.