### PR TITLE
Ameerul / WEBREL-3818 Redirection P2P is not working as expected when user created a USDC account first and then adds fiat account 

### DIFF
--- a/src/routes/CallbackPage.tsx
+++ b/src/routes/CallbackPage.tsx
@@ -27,7 +27,7 @@ const CallbackPage = () => {
             onSignInSuccess={tokens => {
                 const groupedTokens = groupTokens(tokens);
                 const selectedAuthToken =
-                    groupedTokens.find(item => item.cur === 'USD' && item.acct === 'CR')?.token || tokens.token1;
+                    groupedTokens.find(item => item.cur === 'USD' && item.acct?.includes('CR'))?.token || tokens.token1;
 
                 localStorage.setItem('authToken', selectedAuthToken);
 


### PR DESCRIPTION
- Check acct using .includes as the acct can be CR00000 for example, not just CR. So need to check if it CR is included in the string. Cross checked with deriv-api-hooks as this is the same logic we have there

![Screenshot 2025-03-24 at 4 55 12 PM](https://github.com/user-attachments/assets/52295dc6-979f-4db2-b1e2-95786b242023)
