### PR TITLE
Ameerul / ENGT-1800 OIDC Logout freeze issue and Seeing page error in P2P when login with client who previously login to P2P using non USD account.

### DIFF
--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -93,7 +93,7 @@ const useOAuth = (options: { showErrorModal?: () => void } = {}): UseOAuthReturn
                     Cookies.remove('authtoken');
                     window.location.href = window.location.origin;
                 }
-            } else if ((!isAuthorized && !isAuthorizing) || !authTokenLocalStorage) {
+            } else if (!isAuthorized && !isAuthorizing && !authTokenLocalStorage) {
                 await redirectToAuth();
             }
         }

--- a/src/hooks/custom-hooks/useOAuth.ts
+++ b/src/hooks/custom-hooks/useOAuth.ts
@@ -21,7 +21,8 @@ type UseOAuthReturn = {
  * useOAuth - hooks to help with OAuth function such as logout and check auth state during render
  * @returns {UseOAuthReturn}
  */
-const useOAuth = (): UseOAuthReturn => {
+const useOAuth = (options: { showErrorModal?: () => void } = {}): UseOAuthReturn => {
+    const { showErrorModal } = options;
     const [OAuth2EnabledApps, OAuth2EnabledAppsInitialised] = useGrowthbookGetFeatureValue<string>({
         featureFlag: 'hydra_be',
     }) as unknown as [TOAuth2EnabledAppList, boolean];
@@ -37,18 +38,28 @@ const useOAuth = (): UseOAuthReturn => {
     const authTokenLocalStorage = localStorage.getItem('authToken');
 
     const WSLogoutAndRedirect = async () => {
-        await logout();
-        removeCookies('affiliate_token', 'affiliate_tracking', 'utm_data', 'onfido_token', 'gclid');
-        if (!isOAuth2Enabled) {
-            window.open(oauthUrl, '_self');
+        try {
+            await logout();
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to logout', error);
         }
+        removeCookies('affiliate_token', 'affiliate_tracking', 'utm_data', 'onfido_token', 'gclid');
+        redirectToAuth();
     };
+
     const handleLogout = async () => {
-        await OAuth2Logout({
-            postLogoutRedirectUri: window.location.origin,
-            redirectCallbackUri: `${window.location.origin}/callback`,
-            WSLogoutAndRedirect,
-        });
+        try {
+            await OAuth2Logout({
+                postLogoutRedirectUri: window.location.origin,
+                redirectCallbackUri: `${window.location.origin}/callback`,
+                WSLogoutAndRedirect,
+            });
+        } catch (error) {
+            // eslint-disable-next-line no-console
+            console.error('Failed to handle logout', error);
+            showErrorModal?.();
+        }
     };
 
     const redirectToAuth = async () => {
@@ -82,7 +93,7 @@ const useOAuth = (): UseOAuthReturn => {
                     Cookies.remove('authtoken');
                     window.location.href = window.location.origin;
                 }
-            } else if (!isAuthorized && !isAuthorizing && !authTokenLocalStorage) {
+            } else if ((!isAuthorized && !isAuthorizing) || !authTokenLocalStorage) {
                 await redirectToAuth();
             }
         }

--- a/src/routes/CallbackPage.tsx
+++ b/src/routes/CallbackPage.tsx
@@ -26,6 +26,8 @@ const CallbackPage = () => {
         <Callback
             onSignInSuccess={tokens => {
                 const groupedTokens = groupTokens(tokens);
+                localStorage.setItem('clientAccounts', JSON.stringify(groupedTokens));
+
                 const selectedAuthToken =
                     groupedTokens.find(item => item.cur === 'USD' && item.acct?.includes('CR'))?.token || tokens.token1;
 


### PR DESCRIPTION
- Added try catch around logout in `WSLogoutAndRedirect` and `handleLogout` as we did not handle the exception, thus it froze and never did anything else after being called.
- Added a check top level where we cross check the currencies between authorize account list data, and the OIDC tokens. If the currency is not included in the OIDC tokens or if the length of both currency lists do not match.

![Screenshot 2025-03-26 at 2 01 28 PM](https://github.com/user-attachments/assets/7299bfc2-195f-4f30-bee0-d751d3aa34e5)
