### PR TITLE
Ameerul / P2PS-5233 Improve Spacing Between Country Name and Currency Denominator

### DIFF
--- a/src/pages/buy-sell/components/CurrencyDropdown/CurrencySelector/CurrencySelector.tsx
+++ b/src/pages/buy-sell/components/CurrencyDropdown/CurrencySelector/CurrencySelector.tsx
@@ -59,7 +59,7 @@ const CurrencySelector = ({ localCurrencies, onSelectItem, selectedCurrency }: T
                             >
                                 <div
                                     className={clsx(
-                                        'flex justify-between rounded px-[1.6rem] py-[0.8rem] lg:hover:bg-[#d6dadb]',
+                                        'flex justify-between rounded px-[1.6rem] py-[0.8rem] gap-1 lg:hover:bg-[#d6dadb]',
                                         {
                                             'bg-[#d6dadb]': isSelectedCurrency,
                                         }


### PR DESCRIPTION
- Added gap-1 for the div that has country name and currency in CurrencyDropdown

![Screenshot 2025-03-28 at 1 29 19 PM](https://github.com/user-attachments/assets/0f1f0717-800e-4a76-97d3-38938a9dde09)
![Screenshot 2025-03-28 at 1 29 26 PM](https://github.com/user-attachments/assets/41414421-e839-4e45-a7d7-85b9f85a2b7a)
