### PR TITLE
Ameerul / P2PS-5221 Move/Hide Ineligible Ads to the Bottom of the Buy/Sell Page

### DIFF
--- a/src/hooks/api/advert/p2p-advert/useAdvertList.ts
+++ b/src/hooks/api/advert/p2p-advert/useAdvertList.ts
@@ -16,7 +16,14 @@ const useAdvertList = (payload?: TPayload, enabled = true) => {
     const modified_data = useMemo(() => {
         if (!data?.length) return undefined;
 
-        return data.map(advert => ({
+        // Sort the list by is_eligible
+        const sortedList = data.sort((a, b) => {
+            if (a?.is_eligible === b?.is_eligible) return 0;
+            if (a?.is_eligible === 0) return 1; // a goes after b
+            return -1; // a goes before b
+        });
+
+        return sortedList.map(advert => ({
             ...advert,
             advertiser_details: {
                 ...advert?.advertiser_details,


### PR DESCRIPTION
- Sorted the p2p_adverts_list response by is_eligible. is_eligible = 0 will be pushed to the bottom.