### PR TITLE
Ameerul / WEBREL-3927 Sort Functionality - User's Own Ad is coming on Top of the list

### DIFF
--- a/src/components/AdvertsTableRow/AdvertsTableRow.tsx
+++ b/src/components/AdvertsTableRow/AdvertsTableRow.tsx
@@ -155,7 +155,7 @@ const AdvertsTableRow = memo((props: TAdvertsTableRowRenderer) => {
                                     'mb-[-0.5rem]': hasRating,
                                 })}
                             >
-                                <Text size={size} weight={isDesktop ? 400 : 'bold'}>
+                                <Text className='max-w-60 break-all' size={size} weight={isDesktop ? 400 : 'bold'}>
                                     {name}
                                 </Text>
                                 {!!completedOrdersCount && completedOrdersCount >= 100 && (

--- a/src/hooks/api/advert/p2p-advert/useAdvertList.ts
+++ b/src/hooks/api/advert/p2p-advert/useAdvertList.ts
@@ -16,12 +16,11 @@ const useAdvertList = (payload?: TPayload, enabled = true) => {
     const modified_data = useMemo(() => {
         if (!data?.length) return undefined;
 
+        const nonEligibleAdverts = data.filter(advert => advert?.is_eligible === 0);
+        const eligibleAdverts = data.filter(advert => advert?.is_eligible === 1 || advert?.is_eligible === undefined);
+
         // Sort the list by is_eligible
-        const sortedList = data.sort((a, b) => {
-            if (a?.is_eligible === b?.is_eligible) return 0;
-            if (a?.is_eligible === 0) return 1; // a goes after b
-            return -1; // a goes before b
-        });
+        const sortedList = [...eligibleAdverts, ...nonEligibleAdverts];
 
         return sortedList.map(advert => ({
             ...advert,


### PR DESCRIPTION
- Filtered non eligible adverts and eligible adverts then combined to two together, since last time it filtered by comparing the advert with the next advert and our own advert doesn't have is_eligible flag in the object
- Also fixed long names in advert list since it would push the whole column

### Before fix
![Screenshot 2025-04-09 at 10 56 18 AM](https://github.com/user-attachments/assets/0e9e75f9-32a7-41cd-ab74-7d41f1fb345c)
![Screenshot 2025-04-09 at 10 56 29 AM](https://github.com/user-attachments/assets/889a60e2-6996-44b7-bbb4-3a179dd8503b)

### After fix
![Screenshot 2025-04-09 at 10 55 02 AM](https://github.com/user-attachments/assets/7a20c609-58fb-4982-8e05-16c9c9996867)
![Screenshot 2025-04-09 at 10 55 07 AM](https://github.com/user-attachments/assets/b1998cf7-9cef-4a2d-9691-7bdb2da6a633)
