### PR TITLE
Ameerul / WEBREL-3932 Unable To Load The Endpoint Page Header

### DIFF
--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -46,7 +46,7 @@ const AppHeader = () => {
     );
 
     const renderAccountSection = () => {
-        if ((!isEndpointPage && !activeAccount) || isCheckingOidcTokens) {
+        if ((!isEndpointPage && !activeAccount) || (!isEndpointPage && isCheckingOidcTokens)) {
             return <AccountsInfoLoader isLoggedIn isMobile={!isDesktop} speed={3} />;
         }
 


### PR DESCRIPTION
- Added an extra check with isCheckingOidcToken since this is the only thing that could affect the loader in the header since the user is in endpoint page and acctiveAccount is false
