### PR TITLE
Ameerul / TRAH-6189 [OIDC] P2P -  calls that require authorization return invalid token error when the account is being logged out in different platform

### DIFF
--- a/src/hooks/api/account/useActiveAccount.ts
+++ b/src/hooks/api/account/useActiveAccount.ts
@@ -4,8 +4,8 @@ import { useAccountList, useAuthData } from '@deriv-com/api-hooks';
 
 /** A custom hook that returns the account object for the current active account. */
 const useActiveAccount = () => {
-    const { data, ...rest } = useAccountList();
-    const { activeLoginid, data: authData, error } = useAuthData();
+    const { data, error: accountListError, ...rest } = useAccountList();
+    const { activeLoginid, data: authData, error: authError } = useAuthData();
     const { data: balanceData } = api.account.useBalance();
     const activeAccount = useMemo(
         () => data?.find(account => account.loginid === activeLoginid),
@@ -27,7 +27,8 @@ const useActiveAccount = () => {
 
     return {
         /** User's current active account. */
-        authError: error,
+        accountListError,
+        authError,
         data: modifiedAccount,
         ...rest,
     };

--- a/src/routes/AppContent/index.tsx
+++ b/src/routes/AppContent/index.tsx
@@ -25,6 +25,7 @@ const AppContent = () => {
     const location = useLocation();
     const { isDesktop } = useDevice();
     const {
+        accountListError,
         authError,
         data: activeAccountData,
         isFetched,
@@ -156,9 +157,10 @@ const AppContent = () => {
     }, [location]);
 
     useEffect(() => {
-        if (authError?.code === ERROR_CODES.ACCOUNT_DISABLED) oAuthLogout();
+        if (authError?.code === ERROR_CODES.ACCOUNT_DISABLED || accountListError?.code === 'InvalidToken')
+            oAuthLogout();
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [authError, oAuthLogout]);
+    }, [authError, accountListError, oAuthLogout]);
 
     useEffect(() => {
         if (!isGtmTracking.current) {


### PR DESCRIPTION
- Added error check from account list api to logout the user once they come back to p2p after they were logged out from a different window.



https://github.com/user-attachments/assets/18559b88-3359-4326-9ae9-39a65ea967a9

