### PR TITLE
fix: update buy/sell limit info

### DIFF
--- a/src/components/Modals/RemainingBuySellLimitModal/RemainingBuySellLimitModal.scss
+++ b/src/components/Modals/RemainingBuySellLimitModal/RemainingBuySellLimitModal.scss
@@ -1,0 +1,17 @@
+.remaining-buy-sell-limit-modal {
+    @include default-modal;
+    padding: 2.4rem;
+
+    @include mobile-or-tablet-screen {
+        padding: 1.6rem;
+        width: 32.8rem;
+    }
+
+    &__text {
+        margin-bottom: 2.4rem;
+
+        @include mobile-or-tablet-screen {
+            margin-bottom: 1.6rem;
+        }
+    }
+}

--- a/src/components/Modals/RemainingBuySellLimitModal/RemainingBuySellLimitModal.tsx
+++ b/src/components/Modals/RemainingBuySellLimitModal/RemainingBuySellLimitModal.tsx
@@ -1,0 +1,36 @@
+import { Localize } from '@deriv-com/translations';
+import { Button, Modal, Text } from '@deriv-com/ui';
+import { customStyles } from '../helpers';
+import './RemainingBuySellLimitModal.scss';
+
+type TRemainingBuySellLimitModalProps = {
+    isModalOpen: boolean;
+    onRequestClose: () => void;
+};
+
+const RemainingBuySellLimitModal = ({ isModalOpen, onRequestClose }: TRemainingBuySellLimitModalProps) => {
+    return (
+        <Modal
+            ariaHideApp={false}
+            className="remaining-buy-sell-limit-modal"
+            isOpen={isModalOpen}
+            onRequestClose={onRequestClose}
+            shouldCloseOnOverlayClick={false}
+            style={customStyles}
+            testId='dt_remaining_buy_sell_limit_modal'
+        >
+            <Modal.Body>
+                <Text as='p' className="remaining-buy-sell-limit-modal__text" size='sm'>
+                    <Localize i18n_default_text='Amount left to trade today. Limits reset every 24 hours.' />
+                </Text>
+            </Modal.Body>
+            <Modal.Footer className='p-0 min-h-fit' hideBorder>
+                <Button onClick={onRequestClose} size='lg' textSize='sm'>
+                    <Localize i18n_default_text='OK' />
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default RemainingBuySellLimitModal;

--- a/src/components/Modals/RemainingBuySellLimitModal/__tests__/RemainingBuySellLimitModal.spec.tsx
+++ b/src/components/Modals/RemainingBuySellLimitModal/__tests__/RemainingBuySellLimitModal.spec.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RemainingBuySellLimitModal from '../RemainingBuySellLimitModal';
+
+
+describe('RemainingBuySellLimitModal', () => {
+    it('should render the component', () => {
+        render(<RemainingBuySellLimitModal isModalOpen={true} onRequestClose={jest.fn()} />);
+        expect(screen.getByTestId('dt_remaining_buy_sell_limit_modal')).toBeInTheDocument();
+    });
+    it('should close the modal on click of OK button', async () => {
+        const onRequestClose = jest.fn();
+
+        render(<RemainingBuySellLimitModal isModalOpen={true} onRequestClose={onRequestClose} />);
+        const okBtn = screen.getByRole('button', {
+            name: 'OK',
+        });
+        await userEvent.click(okBtn);
+        expect(onRequestClose).toBeCalled();
+    });
+});

--- a/src/components/Modals/RemainingBuySellLimitModal/index.ts
+++ b/src/components/Modals/RemainingBuySellLimitModal/index.ts
@@ -1,0 +1,1 @@
+export { default as RemainingBuySellLimitModal } from './RemainingBuySellLimitModal';

--- a/src/components/Modals/index.ts
+++ b/src/components/Modals/index.ts
@@ -33,6 +33,7 @@ export * from './PreferredCountriesModal';
 export * from './RadioGroupFilterModal';
 export * from './RateFluctuationModal';
 export * from './RatingModal';
+export * from './RemainingBuySellLimitModal';
 export * from './SafetyAlertModal';
 export * from './ShareAdsModal';
 export * from './VideoPlayerModal';

--- a/src/components/ProfileContent/ProfileBalance/ProfileBalance.scss
+++ b/src/components/ProfileContent/ProfileBalance/ProfileBalance.scss
@@ -1,16 +1,24 @@
 .profile-balance {
-    display: grid;
-    grid-template-columns: 1.5fr 3fr;
-    grid-gap: 2.4rem;
+    display: flex;
+    justify-content: space-between;
+
+    @include desktop {
+        margin-left: 8rem;
+        gap: 2.4rem;
+    }
 
     @include mobile-or-tablet-screen {
-        grid-template-columns: 1fr;
-        grid-auto-flow: row;
+        flex-direction: column;
+        gap: 1.6rem;
     }
 
     &__amount {
         display: flex;
         flex-direction: column;
+
+        @include desktop {
+            justify-content: space-between;
+        }
 
         & div {
             display: flex;
@@ -23,12 +31,24 @@
         display: block;
     }
 
+    &__container {
+        display: flex;
+        flex-direction: column;
+
+        @include desktop {
+            padding-left: 4rem;
+            border-left: 1px solid #f2f3f4;
+        }
+    }
+
     &__items {
         display: grid;
         grid-auto-flow: column;
 
         @include mobile-or-tablet-screen {
-            grid-template-columns: 1fr 1fr;
+            grid-auto-flow: row;
+            gap: 0.8rem;
+            margin-bottom: 2.4rem;
         }
     }
 
@@ -42,48 +62,17 @@
     &__item {
         display: flex;
         flex-direction: column;
-        gap: 1.6rem;
 
-        @include mobile-or-tablet-screen {
-            gap: 1rem;
-
-            &:last-child {
-                border-right: none;
-                padding: 0 1.6rem;
+        @include desktop {
+            &:first-child {
+                margin-right: 2.4rem;
+                padding-right: 2.4rem;
+                border-right: 1px solid #f2f3f7;
             }
         }
 
         &-limits {
-            @include desktop {
-                display: flex;
-                margin-bottom: 2.8rem;
-            }
-
-            @include mobile-or-tablet-screen {
-                display: grid;
-                grid-template-columns: 1fr;
-                grid-template-rows: 1fr 1fr;
-                gap: 0.8rem;
-            }
-
-            >div {
-                border-left: 1px solid #f2f3f7;
-                padding: 0 3rem;
-
-                &:first-child {
-                    border-left: none;
-                    padding-left: 0;
-                }
-
-                &:last-child {
-                    padding-right: 0;
-                }
-
-                @include mobile-or-tablet-screen {
-                    border-left: none;
-                    padding: 0;
-                }
-            }
+            display: flex;
         }
     }
 }

--- a/src/components/ProfileContent/ProfileBalance/ProfileBalance.scss
+++ b/src/components/ProfileContent/ProfileBalance/ProfileBalance.scss
@@ -66,13 +66,17 @@
                 gap: 0.8rem;
             }
 
-            & div {
+            >div {
                 border-left: 1px solid #f2f3f7;
                 padding: 0 3rem;
 
                 &:first-child {
                     border-left: none;
                     padding-left: 0;
+                }
+
+                &:last-child {
+                    padding-right: 0;
                 }
 
                 @include mobile-or-tablet-screen {

--- a/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
+++ b/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react';
 import { DeepPartial, TAdvertiserStats } from 'types';
-import { AvailableP2PBalanceModal } from '@/components/Modals';
+import { AvailableP2PBalanceModal, RemainingBuySellLimitModal } from '@/components/Modals';
 import { api } from '@/hooks';
 import { LabelPairedCircleInfoMdRegularIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
@@ -14,6 +14,8 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
     const { isDesktop, isMobile } = useDevice();
     const { localize } = useTranslations();
     const [shouldShowAvailableBalanceModal, setShouldShowAvailableBalanceModal] = useState(false);
+    const [shouldShowRemainingBuySellLimitModal, setShouldShowRemainingBuySellLimitModal] = useState(false);
+
 
     const currency = activeAccount?.currency || 'USD';
     const dailyLimits = useMemo(
@@ -47,6 +49,10 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                 isModalOpen={shouldShowAvailableBalanceModal}
                 onRequestClose={() => setShouldShowAvailableBalanceModal(false)}
             />
+            <RemainingBuySellLimitModal
+                isModalOpen={shouldShowRemainingBuySellLimitModal}
+                onRequestClose={() => setShouldShowRemainingBuySellLimitModal(false)}
+            />
             <div className='profile-balance'>
                 <div className='profile-balance__amount' data-testid='dt_available_balance_amount'>
                     <div>
@@ -70,7 +76,7 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                                 <Text size={labelSize}>{type}</Text>
                                 <div className='profile-balance__item-limits'>
                                     <div data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_limit`}>
-                                        <Text color='less-prominent' size={labelSize}>
+                                        <Text as="div" className="py-[0.2rem]" color='less-prominent' size={labelSize}>
                                             <Localize i18n_default_text='Daily limit' />
                                         </Text>
                                         <Text
@@ -83,9 +89,16 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                                         </Text>
                                     </div>
                                     <div data-testid={`dt_profile_balance_available_${type.toLowerCase()}_limit`}>
-                                        <Text color='less-prominent' size={labelSize}>
-                                            <Localize i18n_default_text='Available' />
-                                        </Text>
+                                        <div className='flex items-center gap-[0.4rem]'>
+                                            <Text color='less-prominent' size={labelSize}>
+                                                <Localize i18n_default_text='Remaining limit' />
+                                            </Text>
+                                            <LabelPairedCircleInfoMdRegularIcon
+                                                className='cursor-pointer fill-gray-400'
+                                                data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_limit_icon`}
+                                                onClick={() => setShouldShowRemainingBuySellLimitModal(true)}
+                                            />
+                                        </div>
                                         <Text
                                             className='profile-balance__label'
                                             data-testid={`dt_profile_balance_available_${type.toLowerCase()}_value`}

--- a/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
+++ b/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
@@ -21,12 +21,12 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
     const dailyLimits = useMemo(
         () => [
             {
-                available: `${FormatUtils.formatMoney(advertiserStats?.dailyAvailableBuyLimit || 0)} ${currency}`,
+                available: `${FormatUtils.formatMoney(advertiserStats?.dailyAvailableBuyLimit || 0)}`,
                 dailyLimit: `${advertiserStats?.daily_buy_limit || FormatUtils.formatMoney(0)} ${currency}`,
                 type: localize('Buy'),
             },
             {
-                available: `${FormatUtils.formatMoney(advertiserStats?.dailyAvailableSellLimit || 0)} ${currency}`,
+                available: `${FormatUtils.formatMoney(advertiserStats?.dailyAvailableSellLimit || 0)}`,
                 dailyLimit: `${advertiserStats?.daily_sell_limit || FormatUtils.formatMoney(0)} ${currency}`,
                 type: localize('Sell'),
             },
@@ -41,7 +41,7 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
         ]
     );
 
-    const labelSize = isMobile ? 'md' : 'sm';
+    const labelSize = isMobile ? 'xl' : 'md';
 
     return (
         <>
@@ -69,45 +69,37 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                         {FormatUtils.formatMoney(advertiserStats?.balance_available || 0)} USD
                     </Text>
                 </div>
-                <div className='flex flex-col gap-[1.6rem]'>
+                <div className='profile-balance__container'>
+                    <div className='flex items-center gap-[0.4rem]'>
+                        <Text color='less-prominent' size={isMobile ? 'xs' : 'sm'}>
+                            <Localize i18n_default_text='Daily limit' />
+                        </Text>
+                        <LabelPairedCircleInfoMdRegularIcon
+                            className='cursor-pointer fill-gray-400'
+                            data-testid='dt_profile_balance_daily_limit_icon'
+                            onClick={() => setShouldShowRemainingBuySellLimitModal(true)}
+                        />
+                    </div>
                     <div className='profile-balance__items'>
                         {dailyLimits.map(({ available, dailyLimit, type }) => (
                             <div className='profile-balance__item' key={type}>
-                                <Text size={labelSize}>{type}</Text>
+                                <Text size={isMobile ? 'lg' : 'md'}>{type}</Text>
                                 <div className='profile-balance__item-limits'>
-                                    <div data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_limit`}>
-                                        <Text as="div" className="py-[0.2rem]" color='less-prominent' size={labelSize}>
-                                            <Localize i18n_default_text='Daily limit' />
-                                        </Text>
-                                        <Text
-                                            className='profile-balance__label'
-                                            data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_value`}
-                                            size={labelSize}
-                                            weight='bold'
-                                        >
-                                            {dailyLimit}
-                                        </Text>
-                                    </div>
-                                    <div data-testid={`dt_profile_balance_available_${type.toLowerCase()}_limit`}>
-                                        <div className='flex items-center gap-[0.4rem]'>
-                                            <Text color='less-prominent' size={labelSize}>
-                                                <Localize i18n_default_text='Remaining limit' />
-                                            </Text>
-                                            <LabelPairedCircleInfoMdRegularIcon
-                                                className='cursor-pointer fill-gray-400'
-                                                data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_limit_icon`}
-                                                onClick={() => setShouldShowRemainingBuySellLimitModal(true)}
-                                            />
-                                        </div>
-                                        <Text
-                                            className='profile-balance__label'
-                                            data-testid={`dt_profile_balance_available_${type.toLowerCase()}_value`}
-                                            size={labelSize}
-                                            weight='bold'
-                                        >
-                                            {available}
-                                        </Text>
-                                    </div>
+                                    <Text
+                                        className='profile-balance__label'
+                                        data-testid={`dt_profile_balance_available_${type.toLowerCase()}_value`}
+                                        size={labelSize}
+                                    >
+                                        {available}&nbsp;
+                                    </Text>
+                                    <Text
+                                        className='profile-balance__label'
+                                        data-testid={`dt_profile_balance_daily_${type.toLowerCase()}_value`}
+                                        size={labelSize}
+                                        weight='bold'
+                                    >
+                                        /&nbsp;{dailyLimit}
+                                    </Text>
                                 </div>
                             </div>
                         ))}

--- a/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
+++ b/src/components/ProfileContent/ProfileBalance/ProfileBalance.tsx
@@ -1,7 +1,7 @@
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { DeepPartial, TAdvertiserStats } from 'types';
 import { AvailableP2PBalanceModal, RemainingBuySellLimitModal } from '@/components/Modals';
-import { api } from '@/hooks';
+import { api, useModalManager } from '@/hooks';
 import { LabelPairedCircleInfoMdRegularIcon } from '@deriv/quill-icons';
 import { Localize, useTranslations } from '@deriv-com/translations';
 import { Text, useDevice } from '@deriv-com/ui';
@@ -13,9 +13,7 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
     const { data: activeAccount } = api.account.useActiveAccount();
     const { isDesktop, isMobile } = useDevice();
     const { localize } = useTranslations();
-    const [shouldShowAvailableBalanceModal, setShouldShowAvailableBalanceModal] = useState(false);
-    const [shouldShowRemainingBuySellLimitModal, setShouldShowRemainingBuySellLimitModal] = useState(false);
-
+    const { hideModal, isModalOpenFor, showModal } = useModalManager();
 
     const currency = activeAccount?.currency || 'USD';
     const dailyLimits = useMemo(
@@ -45,14 +43,6 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
 
     return (
         <>
-            <AvailableP2PBalanceModal
-                isModalOpen={shouldShowAvailableBalanceModal}
-                onRequestClose={() => setShouldShowAvailableBalanceModal(false)}
-            />
-            <RemainingBuySellLimitModal
-                isModalOpen={shouldShowRemainingBuySellLimitModal}
-                onRequestClose={() => setShouldShowRemainingBuySellLimitModal(false)}
-            />
             <div className='profile-balance'>
                 <div className='profile-balance__amount' data-testid='dt_available_balance_amount'>
                     <div>
@@ -62,7 +52,7 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                         <LabelPairedCircleInfoMdRegularIcon
                             className='cursor-pointer fill-gray-400'
                             data-testid='dt_available_balance_icon'
-                            onClick={() => setShouldShowAvailableBalanceModal(true)}
+                            onClick={() => showModal('AvailableP2PBalanceModal')}
                         />
                     </div>
                     <Text data-testid='dt_available_balance_amount_value' size={isMobile ? '2xl' : 'xl'} weight='bold'>
@@ -77,7 +67,7 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                         <LabelPairedCircleInfoMdRegularIcon
                             className='cursor-pointer fill-gray-400'
                             data-testid='dt_profile_balance_daily_limit_icon'
-                            onClick={() => setShouldShowRemainingBuySellLimitModal(true)}
+                            onClick={() => showModal('RemainingBuySellLimitModal')}
                         />
                     </div>
                     <div className='profile-balance__items'>
@@ -111,6 +101,12 @@ const ProfileBalance = ({ advertiserStats }: { advertiserStats: DeepPartial<TAdv
                     )}
                 </div>
             </div>
+            {isModalOpenFor('AvailableP2PBalanceModal') && (
+                <AvailableP2PBalanceModal isModalOpen onRequestClose={hideModal} />
+            )}
+            {isModalOpenFor('RemainingBuySellLimitModal') && (
+                <RemainingBuySellLimitModal isModalOpen onRequestClose={hideModal} />
+            )}
         </>
     );
 };

--- a/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
+++ b/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
@@ -22,6 +22,12 @@ const mockUseActiveAccount = {
     isLoading: false,
 };
 
+const mockModalManager = {
+    hideModal: jest.fn(),
+    isModalOpenFor: jest.fn(),
+    showModal: jest.fn(),
+};
+
 jest.mock('@deriv-com/ui', () => ({
     ...jest.requireActual('@deriv-com/ui'),
     useDevice: jest.fn().mockReturnValue({ isDesktop: true }),
@@ -34,6 +40,7 @@ jest.mock('@/hooks', () => ({
             useActiveAccount: jest.fn(() => mockUseActiveAccount),
         },
     },
+    useModalManager: jest.fn(() => mockModalManager),
 }));
 
 jest.mock('../../ProfileDailyLimit/ProfileDailyLimit', () => jest.fn(() => <div>ProfileDailyLimit</div>));
@@ -46,12 +53,7 @@ describe('ProfileBalance', () => {
 
         const balanceInfoIcon = screen.getByTestId('dt_available_balance_icon');
         await userEvent.click(balanceInfoIcon);
-        expect(screen.getByTestId('dt_available_p2p_balance_modal')).toBeInTheDocument();
-        const okButton = screen.getByRole('button', {
-            name: 'OK',
-        });
-        await userEvent.click(okButton);
-        expect(screen.queryByTestId('dt_available_p2p_balance_modal')).not.toBeInTheDocument();
+        expect(mockModalManager.showModal).toHaveBeenCalledWith('AvailableP2PBalanceModal');
     });
 
     it('should render the correct limits', () => {
@@ -110,11 +112,7 @@ describe('ProfileBalance', () => {
 
         const remainingLimitInfoIcon = screen.getByTestId('dt_profile_balance_daily_limit_icon');
         await userEvent.click(remainingLimitInfoIcon);
-        expect(screen.getByTestId('dt_remaining_buy_sell_limit_modal')).toBeInTheDocument();
-        const okButton = screen.getByRole('button', {
-            name: 'OK',
-        });
-        await userEvent.click(okButton);
-        expect(screen.queryByTestId('dt_remaining_buy_sell_limit_modal')).not.toBeInTheDocument();
+
+        expect(mockModalManager.showModal).toHaveBeenCalledWith('RemainingBuySellLimitModal');
     });
 });

--- a/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
+++ b/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
@@ -65,15 +65,15 @@ describe('ProfileBalance', () => {
             },
         };
         render(<ProfileBalance {...mockAdvertiserStatsProp} />);
-        const dailyBuyLimitNode = screen.getByTestId('dt_profile_balance_daily_buy_limit');
-        expect(within(dailyBuyLimitNode).getByText('500 USD')).toBeInTheDocument();
-        const availableBuyLimitNode = screen.getByTestId('dt_profile_balance_available_buy_limit');
-        expect(within(availableBuyLimitNode).getByText('100.00 USD')).toBeInTheDocument();
+        const dailyBuyLimitNode = screen.getByTestId('dt_profile_balance_daily_buy_value');
+        expect(within(dailyBuyLimitNode).getByText(/500/)).toBeInTheDocument();
+        const availableBuyLimitNode = screen.getByTestId('dt_profile_balance_available_buy_value');
+        expect(within(availableBuyLimitNode).getByText(/100/)).toBeInTheDocument();
 
-        const dailySellLimitNode = screen.getByTestId('dt_profile_balance_daily_sell_limit');
-        expect(within(dailySellLimitNode).getByText('2000 USD')).toBeInTheDocument();
-        const dailyAvailableSellLimit = screen.getByTestId('dt_profile_balance_available_sell_limit');
-        expect(within(dailyAvailableSellLimit).getByText('600.00 USD')).toBeInTheDocument();
+        const dailySellLimitNode = screen.getByTestId('dt_profile_balance_daily_sell_value');
+        expect(within(dailySellLimitNode).getByText(/2000/)).toBeInTheDocument();
+        const dailyAvailableSellLimit = screen.getByTestId('dt_profile_balance_available_sell_value');
+        expect(within(dailyAvailableSellLimit).getByText(/600/)).toBeInTheDocument();
     });
     it('should render ProfileDailyLimit', () => {
         mockAdvertiserStatsProp = {
@@ -94,21 +94,21 @@ describe('ProfileBalance', () => {
         render(<ProfileBalance {...mockAdvertiserStatsProp} />);
         const availableBalanceNode = screen.getByTestId('dt_available_balance_amount');
         expect(within(availableBalanceNode).getByText('0.00 USD')).toBeInTheDocument();
-        const dailyBuyLimitNode = screen.getByTestId('dt_profile_balance_daily_buy_limit');
-        expect(within(dailyBuyLimitNode).getByText('0.00 USD')).toBeInTheDocument();
-        const availableBuyLimitNode = screen.getByTestId('dt_profile_balance_available_buy_limit');
-        expect(within(availableBuyLimitNode).getByText('0.00 USD')).toBeInTheDocument();
+        const dailyBuyLimitNode = screen.getByTestId('dt_profile_balance_daily_buy_value');
+        expect(within(dailyBuyLimitNode).getByText(/0.00/)).toBeInTheDocument();
+        const availableBuyLimitNode = screen.getByTestId('dt_profile_balance_available_buy_value');
+        expect(within(availableBuyLimitNode).getByText(/0.00/)).toBeInTheDocument();
 
-        const dailySellLimitNode = screen.getByTestId('dt_profile_balance_daily_sell_limit');
-        expect(within(dailySellLimitNode).getByText('0.00 USD')).toBeInTheDocument();
-        const dailyAvailableSellLimit = screen.getByTestId('dt_profile_balance_available_sell_limit');
-        expect(within(dailyAvailableSellLimit).getByText('0.00 USD')).toBeInTheDocument();
+        const dailySellLimitNode = screen.getByTestId('dt_profile_balance_daily_sell_value');
+        expect(within(dailySellLimitNode).getByText(/0.00/)).toBeInTheDocument();
+        const dailyAvailableSellLimit = screen.getByTestId('dt_profile_balance_available_sell_value');
+        expect(within(dailyAvailableSellLimit).getByText(/0.00/)).toBeInTheDocument();
     });
 
     it('should render the buy/sell remaining limit info', async () => {
         render(<ProfileBalance {...mockAdvertiserStatsProp} />);
 
-        const remainingLimitInfoIcon = screen.getByTestId('dt_profile_balance_daily_buy_limit_icon');
+        const remainingLimitInfoIcon = screen.getByTestId('dt_profile_balance_daily_limit_icon');
         await userEvent.click(remainingLimitInfoIcon);
         expect(screen.getByTestId('dt_remaining_buy_sell_limit_modal')).toBeInTheDocument();
         const okButton = screen.getByRole('button', {

--- a/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
+++ b/src/components/ProfileContent/ProfileBalance/__tests__/ProfileBalance.spec.tsx
@@ -104,4 +104,17 @@ describe('ProfileBalance', () => {
         const dailyAvailableSellLimit = screen.getByTestId('dt_profile_balance_available_sell_limit');
         expect(within(dailyAvailableSellLimit).getByText('0.00 USD')).toBeInTheDocument();
     });
+
+    it('should render the buy/sell remaining limit info', async () => {
+        render(<ProfileBalance {...mockAdvertiserStatsProp} />);
+
+        const remainingLimitInfoIcon = screen.getByTestId('dt_profile_balance_daily_buy_limit_icon');
+        await userEvent.click(remainingLimitInfoIcon);
+        expect(screen.getByTestId('dt_remaining_buy_sell_limit_modal')).toBeInTheDocument();
+        const okButton = screen.getByRole('button', {
+            name: 'OK',
+        });
+        await userEvent.click(okButton);
+        expect(screen.queryByTestId('dt_remaining_buy_sell_limit_modal')).not.toBeInTheDocument();
+    });
 });

--- a/src/components/ProfileContent/ProfileContent.scss
+++ b/src/components/ProfileContent/ProfileContent.scss
@@ -2,15 +2,19 @@
     display: flex;
     flex-direction: column;
     padding: 2.4rem;
-    gap: 4.8rem;
     border-radius: 0.8rem;
     border: 0.1rem solid #e6e9e9;
+
+    @include desktop {
+        gap: 1.6rem;
+    }
 
     @include mobile-or-tablet-screen {
         border: none;
         border-radius: 0;
         border-bottom: 0.1rem solid #e6e9e9;
         padding: 1.6rem;
+        gap: 3.2rem;
 
         @include tablet {
             border: 0.1rem solid #e6e9e9;


### PR DESCRIPTION
Added a modal for showing the remaining buy/sell limit info.

<img width="1728" alt="Screenshot 2025-04-16 at 9 52 34 AM" src="https://github.com/user-attachments/assets/39f8d89e-d960-416a-b581-4580f6d3983b" />
