### PR TITLE
Remove OIDC redirects if TMB flag is active

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,10 +35,9 @@ const App = () => {
     const mountRef = useRef(false);
 
     useEffect(() => {
-        if (mountRef.current) return;
-
-        const isTMBEnabled = localStorage.getItem('is_tmb_enabled');
+        const isTMBEnabled = JSON.parse(localStorage.getItem('is_tmb_enabled') ?? 'false');
         if (isTMBEnabled) {
+            if (mountRef.current) return;
             onRenderTMBCheck();
         } else {
             onRenderAuthCheck();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useEffect } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
@@ -27,19 +27,24 @@ const App = () => {
     const isProduction = process.env.VITE_NODE_ENV === 'production' || origin === URLConstants.derivP2pProduction;
     const isStaging = process.env.VITE_NODE_ENV === 'staging' || origin === URLConstants.derivP2pStaging;
     const isOAuth2Enabled = isProduction || isStaging;
-    const isTMBEnabled = localStorage.getItem('is_tmb_enabled');
 
     initTrackJS();
     initDerivAnalytics();
     initDatadog();
 
+    const mountRef = useRef(false);
+
     useEffect(() => {
+        if (mountRef.current) return;
+
+        const isTMBEnabled = localStorage.getItem('is_tmb_enabled');
         if (isTMBEnabled) {
             onRenderTMBCheck();
         } else {
             onRenderAuthCheck();
         }
-    }, [onRenderAuthCheck, onRenderTMBCheck, isTMBEnabled]);
+        mountRef.current = true;
+    }, [onRenderAuthCheck, onRenderTMBCheck]);
 
     return (
         <BrowserRouter>

--- a/src/components/AppHeader/AppHeader.tsx
+++ b/src/components/AppHeader/AppHeader.tsx
@@ -94,16 +94,10 @@ const AppHeader = () => {
                 className='w-36'
                 color='primary-light'
                 onClick={async () => {
-                    if (isOAuth2Enabled) {
-                        if (isTMBEnabled) {
-                            await requestOidcAuthentication({
-                                redirectCallbackUri: window.location.origin,
-                            });
-                        } else {
-                            await requestOidcAuthentication({
-                                redirectCallbackUri: `${window.location.origin}/callback`,
-                            });
-                        }
+                    if (isOAuth2Enabled && !isTMBEnabled) {
+                        await requestOidcAuthentication({
+                            redirectCallbackUri: `${window.location.origin}/callback`,
+                        });
                     } else {
                         window.open(oauthUrl, '_self');
                     }

--- a/src/hooks/custom-hooks/useTMB.ts
+++ b/src/hooks/custom-hooks/useTMB.ts
@@ -70,7 +70,7 @@ const useTMB = (options: { showErrorModal?: () => void } = {}): UseTMBReturn => 
     const onRenderTMBCheck = useCallback(async () => {
         const activeSessions = await getActiveSessions();
 
-        if (!activeSessions?.active) {
+        if (!activeSessions?.active && !isEndpointPage) {
             return WSLogoutAndRedirect();
         }
 


### PR DESCRIPTION
## Update:
- Render `useEffect` only once, as currently it is rendering multiple times, slowing down the application initialization
- Remove Hydra redirects if `TMB` flag is enabled all together. 
- As per BE, no need to do OAuth logout in case of TMB session
- Token sequence can be random from `/active` endpoint
- Updated logic to get the save the appropriate auth token as per logic from `/callback` page