### PR TITLE
farrah/fix: authorizing of accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
                 "@chakra-ui/react": "^2.8.2",
                 "@datadog/browser-rum": "^5.11.0",
                 "@deriv-com/analytics": "^1.27.0",
-                "@deriv-com/api-hooks": "^1.7.1",
+                "@deriv-com/api-hooks": "^1.7.2",
                 "@deriv-com/auth-client": "1.5.1",
                 "@deriv-com/translations": "^1.3.9",
                 "@deriv-com/ui": "^1.35.6",
@@ -3864,9 +3864,9 @@
             }
         },
         "node_modules/@deriv-com/api-hooks": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@deriv-com/api-hooks/-/api-hooks-1.7.1.tgz",
-            "integrity": "sha512-6DLPlIRHp8okvuIcgVk556wSc5YaBBGhJjFBQYFDMu5mXHrbzJuEdNE2hOM6y7+ZRQnNEeJ67okF5CWzeL318w==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/@deriv-com/api-hooks/-/api-hooks-1.7.2.tgz",
+            "integrity": "sha512-KYlykWmvXJrAWtZrHs6jzsC4X8bNU528aK84M4Oa6MZcER59xfU9A8jolKoxhVRYPxV3R6wgRF84cQd2ZXXeUg==",
             "dependencies": {
                 "@deriv-com/utils": "^0.0.30",
                 "@deriv/api-types": "^1.0.1449",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "@chakra-ui/react": "^2.8.2",
         "@datadog/browser-rum": "^5.11.0",
         "@deriv-com/analytics": "^1.27.0",
-        "@deriv-com/api-hooks": "^1.7.1",
+        "@deriv-com/api-hooks": "^1.7.2",
         "@deriv-com/auth-client": "1.5.1",
         "@deriv-com/translations": "^1.3.9",
         "@deriv-com/ui": "^1.35.6",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryParamProvider } from 'use-query-params';
 import { ReactRouter5Adapter } from 'use-query-params/adapters/react-router-5';
 import { AppFooter, AppHeader, DerivIframe, ErrorBoundary } from '@/components';
-import { useDatadog, useDerivAnalytics, useOAuth, useTMB, useTrackjs } from '@/hooks';
+import { useDatadog, useDerivAnalytics, useIsP2PBlocked, useOAuth, useTMB, useTrackjs } from '@/hooks';
 import AppContent from '@/routes/AppContent';
 import { initializeI18n, TranslationProvider } from '@deriv-com/translations';
 import { Loader, useDevice } from '@deriv-com/ui';
@@ -27,6 +27,7 @@ const App = () => {
     const isProduction = process.env.VITE_NODE_ENV === 'production' || origin === URLConstants.derivP2pProduction;
     const isStaging = process.env.VITE_NODE_ENV === 'staging' || origin === URLConstants.derivP2pStaging;
     const isOAuth2Enabled = isProduction || isStaging;
+    const { isP2PCurrencyBlocked } = useIsP2PBlocked();
 
     initTrackJS();
     initDerivAnalytics();
@@ -58,9 +59,9 @@ const App = () => {
                             }
                         >
                             {!isOAuth2Enabled && <DerivIframe />}
-                            {!isCallbackPage && <AppHeader />}
+                            {!isCallbackPage && !isP2PCurrencyBlocked && <AppHeader />}
                             <AppContent />
-                            {isDesktop && !isCallbackPage && <AppFooter />}
+                            {isDesktop && !isCallbackPage && !isP2PCurrencyBlocked && <AppFooter />}
                         </Suspense>
                     </TranslationProvider>
                 </QueryParamProvider>

--- a/src/components/BlockedScenarios/BlockedScenarios.tsx
+++ b/src/components/BlockedScenarios/BlockedScenarios.tsx
@@ -37,12 +37,12 @@ const BlockedScenarios = ({ type }: { type: string }) => {
         crypto: {
             actionButton: (
                 <Button onClick={openDerivApp} size='lg' textSize={buttonTextSize}>
-                    <Localize i18n_default_text='Switch to real USD account' />
+                    <Localize i18n_default_text='Create real USD account' />
                 </Button>
             ),
             description: (
                 <Text align='center'>
-                    <Localize i18n_default_text='To use Deriv P2P, switch to your real USD account.' />
+                    <Localize i18n_default_text='To use Deriv P2P, create your real USD account.' />
                 </Text>
             ),
             icon: <P2pUnavailable height={iconSize} width={iconSize} />,

--- a/src/components/BlockedScenarios/BlockedScenarios.tsx
+++ b/src/components/BlockedScenarios/BlockedScenarios.tsx
@@ -7,7 +7,6 @@ import {
 } from '@deriv/quill-icons';
 import { Localize } from '@deriv-com/translations';
 import { ActionScreen, Button, Text, useDevice } from '@deriv-com/ui';
-import { URLConstants } from '@deriv-com/utils';
 
 type TBlockedScenariosObject = {
     [key: string]: {
@@ -27,7 +26,7 @@ const BlockedScenarios = ({ type }: { type: string }) => {
 
     // TODO: change redirection when account switcher is implemented
     const openDerivApp = () => {
-        window.open(URLConstants.derivAppProduction, '_blank')?.focus();
+        window.open(redirectLink);
     };
 
     const openLiveChat = () => {
@@ -73,13 +72,13 @@ const BlockedScenarios = ({ type }: { type: string }) => {
         },
         nonUSD: {
             actionButton: (
-                <Button onClick={openDerivApp} size='lg' textSize={buttonTextSize}>
-                    <Localize i18n_default_text='Create real USD account' />
+                <Button onClick={openLiveChat} size='lg' textSize={buttonTextSize}>
+                    <Localize i18n_default_text='Live chat' />
                 </Button>
             ),
             description: (
                 <Text align='center'>
-                    <Localize i18n_default_text='Please create a Real USD account to access the Deriv P2P marketplace.' />
+                    <Localize i18n_default_text='Please use live chat to contact our Customer Support team for help.' />
                 </Text>
             ),
             icon: <P2pUnavailable height={iconSize} width={iconSize} />,

--- a/src/components/BlockedScenarios/__tests__/BlockedScenarios.spec.tsx
+++ b/src/components/BlockedScenarios/__tests__/BlockedScenarios.spec.tsx
@@ -47,7 +47,7 @@ describe('BlockedScenarios', () => {
     it('should render the correct message for crypto account', async () => {
         render(<BlockedScenarios type='crypto' />);
         expect(screen.getByText('Cryptocurrencies not supported')).toBeInTheDocument();
-        const button = screen.getByRole('button', { name: 'Switch to real USD account' });
+        const button = screen.getByRole('button', { name: 'Create real USD account' });
         await userEvent.click(button);
         expect(window.open).toHaveBeenCalledWith('https://app.deriv.com');
     });

--- a/src/components/BlockedScenarios/__tests__/BlockedScenarios.spec.tsx
+++ b/src/components/BlockedScenarios/__tests__/BlockedScenarios.spec.tsx
@@ -35,15 +35,13 @@ describe('BlockedScenarios', () => {
         expect(screen.getByText('You are using a demo account')).toBeInTheDocument();
         const button = screen.getByRole('button', { name: 'Switch to real USD account' });
         await userEvent.click(button);
-        expect(window.open).toHaveBeenCalledWith('https://app.deriv.com', '_blank');
+        expect(window.open).toHaveBeenCalledWith('https://app.deriv.com');
     });
 
     it('should render the correct message for non-USD account', async () => {
         render(<BlockedScenarios type='nonUSD' />);
         expect(screen.getByText('You have no Real USD account')).toBeInTheDocument();
-        const button = screen.getByRole('button', { name: 'Create real USD account' });
-        await userEvent.click(button);
-        expect(window.open).toHaveBeenCalledWith('https://app.deriv.com', '_blank');
+        expect(screen.getByRole('button', { name: 'Live chat' })).toBeInTheDocument();
     });
 
     it('should render the correct message for crypto account', async () => {
@@ -51,7 +49,7 @@ describe('BlockedScenarios', () => {
         expect(screen.getByText('Cryptocurrencies not supported')).toBeInTheDocument();
         const button = screen.getByRole('button', { name: 'Switch to real USD account' });
         await userEvent.click(button);
-        expect(window.open).toHaveBeenCalledWith('https://app.deriv.com', '_blank');
+        expect(window.open).toHaveBeenCalledWith('https://app.deriv.com');
     });
 
     it('should show the correct message for p2p is blocked for user', () => {

--- a/src/constants/account.ts
+++ b/src/constants/account.ts
@@ -1,0 +1,2 @@
+export const ACCOUNT_TYPES = ['CR', 'MF'];
+export const CURRENCIES = ['USD', 'EUR', 'GBP'];

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,4 @@
+export * from './account';
 export * from './ad-constants';
 export * from './api-error-codes';
 export * from './buy-sell';

--- a/src/hooks/custom-hooks/__tests__/useIsP2PBlocked.spec.ts
+++ b/src/hooks/custom-hooks/__tests__/useIsP2PBlocked.spec.ts
@@ -21,7 +21,11 @@ const mockUseActiveAccount = api.account.useActiveAccount as jest.Mock;
 describe('useIsP2PBlocked', () => {
     it('should return isP2PBlocked as undefined and status as empty string when accountStatus is not defined', () => {
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: false, status: 'p2pBlocked' });
+        expect(result.current).toStrictEqual({
+            isP2PBlocked: false,
+            isP2PCurrencyBlocked: false,
+            status: 'p2pBlocked',
+        });
     });
 
     it('should return isP2PBlocked as false and status as empty string if user can use p2p', () => {
@@ -29,7 +33,11 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'USD', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: false, status: 'p2pBlocked' });
+        expect(result.current).toStrictEqual({
+            isP2PBlocked: false,
+            isP2PCurrencyBlocked: false,
+            status: 'p2pBlocked',
+        });
     });
 
     it('should return isP2PBlocked as true and status as p2pBlocked if p2p_status is perm banned', () => {
@@ -37,7 +45,7 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'USD', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'p2pBlocked' });
+        expect(result.current).toStrictEqual({ isP2PBlocked: true, isP2PCurrencyBlocked: false, status: 'p2pBlocked' });
     });
 
     it('should return isP2PBlocked as true and status as systemMaintenance if cashier_validation has system_maintenance', () => {
@@ -47,7 +55,11 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'USD', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'systemMaintenance' });
+        expect(result.current).toStrictEqual({
+            isP2PBlocked: true,
+            isP2PCurrencyBlocked: false,
+            status: 'systemMaintenance',
+        });
     });
 
     it('should return isP2PBlocked as true and status as crypto if currency_type is crypto', () => {
@@ -55,7 +67,7 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency_type: 'crypto', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'crypto' });
+        expect(result.current).toStrictEqual({ isP2PBlocked: true, isP2PCurrencyBlocked: true, status: 'crypto' });
     });
 
     it('should return isP2PBlocked as true and status as demo if account is virtual', () => {
@@ -63,7 +75,7 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'USD', is_virtual: 1 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'demo' });
+        expect(result.current).toStrictEqual({ isP2PBlocked: true, isP2PCurrencyBlocked: true, status: 'demo' });
     });
 
     it('should return isP2PBlocked as true and status as nonUSD if currency is not USD', () => {
@@ -71,7 +83,7 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'EUR', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'nonUSD' });
+        expect(result.current).toStrictEqual({ isP2PBlocked: true, isP2PCurrencyBlocked: true, status: 'nonUSD' });
     });
 
     it('should return isP2PBlocked as true and status as p2pBlockedForPa if status includes p2p_blocked_for_pa', () => {
@@ -81,6 +93,10 @@ describe('useIsP2PBlocked', () => {
         mockUseActiveAccount.mockImplementation(() => ({ data: { currency: 'USD', is_virtual: 0 } }));
 
         const { result } = renderHook(() => useIsP2PBlocked());
-        expect(result.current).toStrictEqual({ isP2PBlocked: true, status: 'p2pBlockedForPa' });
+        expect(result.current).toStrictEqual({
+            isP2PBlocked: true,
+            isP2PCurrencyBlocked: false,
+            status: 'p2pBlockedForPa',
+        });
     });
 });

--- a/src/hooks/custom-hooks/useIsP2PBlocked.ts
+++ b/src/hooks/custom-hooks/useIsP2PBlocked.ts
@@ -28,9 +28,10 @@ const useIsP2PBlocked = () => {
     );
 
     const isP2PBlocked = Boolean(accountBlockStatus || blockedType);
+    const isP2PCurrencyBlocked = Boolean(blockedType);
     const status = blockedType ?? accountBlockStatus;
 
-    return { isP2PBlocked, status: status || 'p2pBlocked' };
+    return { isP2PBlocked, isP2PCurrencyBlocked, status: status || 'p2pBlocked' };
 };
 
 export default useIsP2PBlocked;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { ACCOUNT_TYPES, CURRENCIES } from '@/constants';
 import { AppDataProvider } from '@deriv-com/api-hooks';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import App from './App';
@@ -8,7 +9,7 @@ import './main.scss';
 ReactDOM.createRoot(document.getElementById('root')!).render(
     <React.StrictMode>
         <QueryClientProvider client={new QueryClient()}>
-            <AppDataProvider accountType='CR' currency='USD'>
+            <AppDataProvider accountTypes={ACCOUNT_TYPES} currencies={CURRENCIES}>
                 <App />
             </AppDataProvider>
         </QueryClientProvider>

--- a/src/routes/CallbackPage.tsx
+++ b/src/routes/CallbackPage.tsx
@@ -1,4 +1,5 @@
 import { memo } from 'react';
+import { ACCOUNT_TYPES, CURRENCIES } from '@/constants';
 import { Callback } from '@deriv-com/auth-client';
 
 type TTokens = {
@@ -29,7 +30,12 @@ const CallbackPage = () => {
                 localStorage.setItem('clientAccounts', JSON.stringify(groupedTokens));
 
                 const selectedAuthToken =
-                    groupedTokens.find(item => item.cur === 'USD' && item.acct?.includes('CR'))?.token || tokens.token1;
+                    groupedTokens.find(
+                        item =>
+                            item.cur &&
+                            CURRENCIES.includes(item.cur) &&
+                            ACCOUNT_TYPES.some(accountType => item.acct?.includes(accountType))
+                    )?.token || tokens.token1;
 
                 localStorage.setItem('authToken', selectedAuthToken);
 


### PR DESCRIPTION
Handle the scenarios for authorizing accounts when redirecting from Trader's Hub OS to P2P. Instead of only authorizing USD account by default, we need to authorize non-USD real accounts too. 