### PR TITLE
Ameerul / ENGT-2414 On Responsive mode seeing Infinite loading on tapping Back button from P2P page

### DIFF
--- a/src/routes/AppContent/index.tsx
+++ b/src/routes/AppContent/index.tsx
@@ -87,6 +87,14 @@ const AppContent = () => {
         window.addEventListener('unhandledrejection', () => {
             showModal('ErrorModal');
         });
+
+        window.addEventListener('popstate', () => {
+            // If the user navigates back to the root route, we need to go back more steps to ensure
+            // the user is redirected to the previous app such as deriv app
+            if (window.location.pathname === '/') {
+                window.history.go(-1); // Loops back to the previous page until it reaches a non-root route
+            }
+        });
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
- Added popstate window listener to listen when the user clicks the back button for browser. If they do, and it tries to navigate to the base route when trying to return to deriv app or other apps, it will keep looping and navigating backwards until they are navigated to the original origin.