### PR TITLE
Ameerul / P2PS-5330 [Edit Business Hours] - Unable to close edit business hour dialog

### DIFF
--- a/src/components/Modals/BusinessHoursModal/BusinessHoursModal.tsx
+++ b/src/components/Modals/BusinessHoursModal/BusinessHoursModal.tsx
@@ -21,13 +21,13 @@ const BusinessHoursModal = ({ hideModal, isModalOpen }: TBusinessHoursModalProps
     const { hideModal: hideCancelModal, isModalOpenFor, showModal } = useModalManager();
     const { isDesktop } = useDevice();
     const { businessHours } = useGetBusinessHours();
-    const { isSuccess, mutate } = api.advertiser.useUpdate();
+    const { isSuccess, mutateAsync } = api.advertiser.useUpdate();
     const [isDisabled, setIsDisabled] = useState(true);
     const [showEdit, setShowEdit] = useState(false);
     const [editedBusinessHours, setEditedBusinessHours] = useState<TData[]>(businessHours);
     const [shouldCloseModal, setShouldCloseModal] = useState(false);
 
-    const onSave = useCallback(() => {
+    const onSave = useCallback(async () => {
         const filteredTimes = editedBusinessHours.filter(day => day.start_time !== null || day.end_time !== null);
         const result = convertToMinutesRange(filteredTimes as TBusinessDay[]);
         const offset = new Date().getTimezoneOffset();
@@ -35,8 +35,9 @@ const BusinessHoursModal = ({ hideModal, isModalOpen }: TBusinessHoursModalProps
             day => day.start_min !== null || day.end_min !== null
         );
 
-        mutate({ schedule: convertedResult });
-    }, [editedBusinessHours, mutate]);
+        await mutateAsync({ schedule: convertedResult });
+        setShowEdit(false);
+    }, [editedBusinessHours, mutateAsync]);
 
     const onClickCancel = useCallback(() => {
         const isEdited = isTimeEdited(businessHours, editedBusinessHours);

--- a/src/components/Modals/BusinessHoursModal/__tests__/BusinessHoursModal.spec.tsx
+++ b/src/components/Modals/BusinessHoursModal/__tests__/BusinessHoursModal.spec.tsx
@@ -17,7 +17,7 @@ const mockModalManager = {
 
 const mockUseUpdate = {
     isSuccess: true,
-    mutate: jest.fn(),
+    mutateAsync: jest.fn(),
 };
 
 jest.mock('@deriv-com/ui', () => ({
@@ -117,7 +117,7 @@ describe('<BusinessHoursModal />', () => {
         expect(saveButton).toBeEnabled();
         await user.click(saveButton);
 
-        expect(mockUseUpdate.mutate).toHaveBeenCalled();
+        expect(mockUseUpdate.mutateAsync).toHaveBeenCalled();
     });
 
     it('should reset the dropdown values when Reset icon is clicked', async () => {


### PR DESCRIPTION
- replaced mutate with mutateAsync, this way we properly await for the mutation to be done, then call setShowEdit with false to hide the edit page.