### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync-translations.yml
+++ b/.github/workflows/sync-translations.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: '0 */12 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   sync_translations:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p/security/code-scanning/10](https://github.com/deriv-com/p2p/security/code-scanning/10)

To fix the issue, we need to add an explicit `permissions` block to the workflow. This block will specify the minimal privileges required for the workflow's tasks. Based on the workflow's purpose:
- The `contents: read` permission is necessary to allow the workflow to read repository files during the checkout step.
- Other permissions, such as `contents: write`, are not explicitly required for the tasks shown in the workflow and should be avoided.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs or within the specific job (`sync_translations`) for fine-grained control.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
