### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -6,6 +6,8 @@ on:
         types: [opened, synchronize, edited]
 
 name: Coveralls
+permissions:
+  contents: read
 jobs:
     build:
         name: Reporter


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p/security/code-scanning/7](https://github.com/deriv-com/p2p/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves checking out the repository, setting up Node.js, installing dependencies, running tests, and reporting coverage, it only requires `contents: read` permissions. This ensures that the workflow has the minimal access necessary to perform its tasks.

The `permissions` block will be added at the root of the workflow file, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
