### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -1,4 +1,7 @@
 name: Build staging and Deploy to Cloudflare Pages
+permissions:
+  contents: read
+  pages: write
 
 on:
     push:


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p/security/code-scanning/5](https://github.com/deriv-com/p2p/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are likely required:
- `contents: read` for accessing the repository's contents.
- `pages: write` for publishing to Cloudflare Pages.
- `id-token: write` if any actions require OIDC tokens (not explicitly seen here but may be needed for some secrets).

The `permissions` block will be added after the `name` field at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
