### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-deploy-prod.yml
+++ b/.github/workflows/build-and-deploy-prod.yml
@@ -9,6 +9,9 @@ concurrency:
     group: cloudflare-pages-build-production
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     build_to_cloudflare_pages:
         timeout-minutes: 30


### PR DESCRIPTION
Potential fix for [https://github.com/deriv-com/p2p/security/code-scanning/9](https://github.com/deriv-com/p2p/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the least privileges required for the workflow to function correctly. Since the workflow does not perform any repository modifications, we will set `contents: read` as the minimal permission. This ensures the `GITHUB_TOKEN` has read-only access to the repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
